### PR TITLE
Allow main_frame navigations to LAN addresses (#57)

### DIFF
--- a/background.js
+++ b/background.js
@@ -28,6 +28,15 @@ async function cancel(requestDetails) {
     }
 
 
+    // Top-level navigations (user-initiated tab loads) cannot be used for port
+    // scanning — each probe would open a visible new tab and destroy the attack
+    // page. Allow them unconditionally so legitimate LAN links (Proxmox, VPN
+    // consoles, local dev servers) are not broken.
+    if (requestDetails.type === "main_frame") {
+        console.debug("Top-level navigation to local resource allowed:", requestDetails.url);
+        return { cancel: false };
+    }
+
     // Then check the allowlist
     let check_allowed_url;
     try {


### PR DESCRIPTION
## Problem

Firefox's `webRequest.onBeforeRequest` sets `originUrl` to the page that *contains the link*, not to the tab doing the navigation. When a user clicks a link to `http://localhost:8080` from an external page (e.g., GitHub), the request arrives with `originUrl = github.com` and `thirdParty = true` — indistinguishable from a JS port scan attempt. The request is blocked.

This breaks legitimate workflows: Proxmox shell connections, VPN web consoles, local dev server links in documentation, etc.

Reported in #57.

## Fix

Added an early return for `requestDetails.type === "main_frame"` immediately after the same-origin guard and before the allowlist check.

**Why `main_frame` is safe to allow:** A port scanner cannot use top-level navigations — each probe would open a new visible browser tab and navigate the user away from the attack page, destroying the scan. Port scanning exclusively uses sub-resource request types (`xmlhttprequest`, `sub_frame`, `image`, etc.), which continue to be blocked.

Only `main_frame` is relaxed. All sub-resource loads from external origins to local addresses remain blocked as before.

## Testing

1. Load the extension from source in Firefox
2. Visit any external page with an `<a href="http://localhost:PORT">` link  
3. Click the link — it should now open successfully instead of failing to load
4. Confirm that JS `fetch("http://localhost:PORT")` from an external page is still blocked

Closes #57