### PR TITLE
Fix DNS rebinding bypass (#69)

### DIFF
--- a/background.js
+++ b/background.js
@@ -20,6 +20,20 @@ const local_filter = new RegExp("\\b(^(http|https|wss|ws|ftp|ftps):\/\/127[.](?:
 // Create a regex to find all sub-domains for online-metrix.net  Explained here https://regex101.com/r/f8LSTx/2
 const thm = new RegExp("online-metrix[.]net$", "i");
 
+function isPrivateIPv4(ip) {
+    const parts = ip.split(".").map(Number);
+    if (parts.length !== 4 || parts.some(isNaN)) return false;
+    const [a, b] = parts;
+    return (
+        a === 127 ||
+        a === 10 ||
+        (a === 172 && b >= 16 && b <= 31) ||
+        (a === 192 && b === 168) ||
+        (a === 169 && b === 254) ||
+        (a === 0 && parts.every(p => p === 0))
+    );
+}
+
 async function cancel(requestDetails) {
     // First check if it's a same-origin request
     if(!requestDetails.thirdParty) {
@@ -64,13 +78,29 @@ async function cancel(requestDetails) {
         return { cancel: true };
     }
 
-    // The early return in the if case above makes sure we are not searching the CNAME of local addresses
-    // Send a request to get the CNAME of the webrequest
-    const resolving = await browser.dns.resolve(url.host, ["canonical_name"]);
-    // If the CNAME redirects to a online-metrix.net domain -> Block
+    // Resolve hostname once; check both private-IP and ThreatMetrix CNAME.
+    let resolving;
+    try {
+        resolving = await browser.dns.resolve(url.host, ["canonical_name"]);
+    } catch (e) {
+        // Fail open — DNS failure should not break valid but temporarily
+        // unresolvable domains (captive portals, split-horizon DNS, etc.)
+        console.warn("DNS resolution failed for:", url.host, e);
+        return { cancel: false };
+    }
+
+    for (const address of resolving.addresses ?? []) {
+        if (isPrivateIPv4(address)) {
+            console.debug("Blocking domain: DNS resolved to private IP:", { url, address });
+            increaseBadge(requestDetails, false);
+            addBlockedPortToHost(url, requestDetails.tabId);
+            return { cancel: true };
+        }
+    }
+
     if (thm.test(resolving.canonicalName)) {
-        console.debug("Blocking domain for being a threatmetrix match: ", {url: url, cname: resolving.canonicalName});
-        increaseBadge(requestDetails, true); // increment badge and alert
+        console.debug("Blocking domain for ThreatMetrix CNAME:", { url, cname: resolving.canonicalName });
+        increaseBadge(requestDetails, true);
         addBlockedTrackingHost(url, requestDetails.tabId);
         return { cancel: true };
     }


### PR DESCRIPTION
## Problem

The `local_filter` regex in `cancel()` only matches requests whose URL contains a literal local IP address or `localhost`. A hostname like `attacker.com` that resolves to `127.0.0.1` passes all checks unblocked:

1. `thirdParty: true` — passes same-origin guard
2. Not in allowlist — passes whitelist check  
3. `local_filter` regex — no match (URL contains the hostname, not the IP)
4. DNS was only used for ThreatMetrix CNAME detection, not IP validation

Reported in #69.

## Fix

Added a pure `isPrivateIPv4(ip)` helper that covers all RFC-1918, loopback (127.0.0.0/8), link-local (169.254.0.0/16), and 0.0.0.0 ranges.

Updated the DNS resolution block to call `browser.dns.resolve()` once and check both:
- Whether any resolved address is a private IP → block as port scan
- Whether the CNAME chain hits ThreatMetrix → block as tracker

The existing `dns` permission and `browser.dns.resolve()` usage are unchanged. The `local_filter` regex is kept as a fast pre-filter for literal-IP URLs.

**Fail-open on DNS error** — resolution failures (NXDOMAIN, captive portals, split-horizon DNS) allow the request through rather than breaking legitimate browsing.

## Testing

Load the extension from source, open the browser console, and verify a domain with an A record pointing to 127.0.0.1 is blocked while a non-local domain is allowed.

Closes #69