### PR TITLE
feat: add Selective Allow popup for cross-origin local navigation (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,28 @@ This addon blocks websites from using javascript to port scan your computer/inte
 4. Provides an optional whitelist to prevent portscans and tracking scripts from being blocked on trusted domains
 5. Gives a nice notification when one of the above scenarios are blocked
 6. This addon doesn't store/transmit/log any data or metadata about you or your requests... because, ya know, privacy
+7. Prompts you when a page from the internet tries to navigate you to a local address, letting you allow or block on a per-origin basis
+
+## Selective Allow — Cross-Origin Local Navigation
+
+When a page on the internet contains a link to a local address (e.g. `http://localhost:8080`), Port Authority blocks the navigation by default. Rather than failing silently, it opens a small popup so you can decide what to do.
+
+**The popup shows:**
+- The external origin that contained the link (e.g. `github.com`)
+- The local address being navigated to
+- The request protocol
+
+**Your options:**
+
+| Button | Effect |
+|--------|--------|
+| **Block** | Request stays blocked. Nothing is saved. |
+| **Allow Once** | Allowed for the rest of this browser session. Resets on browser restart. |
+| **Always Allow** | The `origin → destination` pair is saved to extension settings. Future navigations from the same origin to the same local address are allowed immediately without prompting. |
+
+Saved "Always Allow" entries can be reviewed and removed from the extension settings page (gear icon in the popup).
+
+> **Note:** This prompt only appears for full page navigations (clicking a link that opens a new tab). Background requests from web pages to local addresses — `fetch`, XHR, iframes — are still silently blocked and logged in the extension popup. Those are the primary port-scanning vector and are never prompted.
 
 ## Donations
 - Monero Address: `89jYJvX3CaFNv1T6mhg69wK5dMQJSF3aG2AYRNU1ZSo6WbccGtJN7TNMAf39vrmKNR6zXUKxJVABggR4a8cZDGST11Q4yS8`

--- a/background.js
+++ b/background.js
@@ -1,5 +1,6 @@
 import { getItemFromLocal, setItemInLocal, modifyItemInLocal,
     addBlockedPortToHost, addBlockedTrackingHost, increaseBadge } from "./global/BrowserStorageManager.js";
+import { openSelectiveAllowPopup } from "./global/browserActions.js";
 
 async function startup(){
     // No need to check and initialize notification, state, and allow list values as they will 
@@ -19,6 +20,10 @@ async function startup(){
 const local_filter = new RegExp("\\b(^(http|https|wss|ws|ftp|ftps):\/\/127[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|^(http|https|wss|ws|ftp|ftps):\/\/0.0.0.0|^(http|https|wss|ws|ftp|ftps):\/\/(10)([.](25[0-5]|2[0-4][0-9]|1[0-9]{1,2}|[0-9]{1,2})){3}|^(http|https|wss|ws|ftp|ftps):\/\/localhost|^(http|https|wss|ws|ftp|ftps):\/\/172[.](0?16|0?17|0?18|0?19|0?20|0?21|0?22|0?23|0?24|0?25|0?26|0?27|0?28|0?29|0?30|0?31)[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|^(http|https|wss|ws|ftp|ftps):\/\/192[.]168[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|^(http|https|wss|ws|ftp|ftps):\/\/169[.]254[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))(?:\/([789]|1?[0-9]{2}))?\\b", "i");
 // Create a regex to find all sub-domains for online-metrix.net  Explained here https://regex101.com/r/f8LSTx/2
 const thm = new RegExp("online-metrix[.]net$", "i");
+
+// In-memory session allow set for cross-origin local navigations.
+// Keys are "origin|destination" strings. Cleared on browser restart.
+const sessionAllowSet = new Set();
 
 async function cancel(requestDetails) {
     // First check if it's a same-origin request
@@ -54,6 +59,28 @@ async function cancel(requestDetails) {
         console.error("Error filtering on domain due to unparseable request URL: ", requestDetails.url, error);
     }
 
+
+    // Top-level navigations (user-clicked links) to local addresses get a
+    // selective allow prompt rather than a silent block. Port scanners cannot
+    // use main_frame — each probe opens a visible new tab and destroys the
+    // attack page.
+    if (requestDetails.type === "main_frame" && local_filter.test(requestDetails.url)) {
+        const origin = check_allowed_url.host;
+        const destination = url.host;
+        const allowKey = `${origin}|${destination}`;
+
+        if (sessionAllowSet.has(allowKey)) {
+            return { cancel: false };
+        }
+
+        const crossOriginList = await getItemFromLocal("cross_origin_allowlist", []);
+        if (crossOriginList.some(e => e.origin === origin && e.destination === destination)) {
+            return { cancel: false };
+        }
+
+        openSelectiveAllowPopup(origin, destination, requestDetails.url);
+        return { cancel: true };
+    }
 
     // Local request check
     if (local_filter.test(requestDetails.url)) {
@@ -173,6 +200,23 @@ async function onMessage(message, sender) {
         case 'toggleEnabled':
             message.value ? await start() : await stop();
             break;
+
+        case 'allowOnce':
+            sessionAllowSet.add(`${message.origin}|${message.destination}`);
+            browser.tabs.create({ url: message.originalUrl });
+            break;
+
+        case 'alwaysAllow':
+            sessionAllowSet.add(`${message.origin}|${message.destination}`);
+            await modifyItemInLocal("cross_origin_allowlist", [], (list) => {
+                if (!list.some(e => e.origin === message.origin && e.destination === message.destination)) {
+                    list.push({ origin: message.origin, destination: message.destination });
+                }
+                return list;
+            });
+            browser.tabs.create({ url: message.originalUrl });
+            break;
+
         default:
             console.warn('Port Authority: unknown message: ', message);
             break;

--- a/global/browserActions.js
+++ b/global/browserActions.js
@@ -57,15 +57,16 @@ export async function getActiveTabId() {
 }
 
 /**
- * Opens the Selective Allow decision popup for a blocked cross-origin local navigation.
- * @param {string} origin The host of the page that contained the link (e.g. "github.com")
- * @param {string} destination The local host:port being navigated to (e.g. "localhost:8080")
+ * Opens a Selective Allow decision popup.
+ * @param {string} origin The host of the page that initiated the request (e.g. "github.com")
+ * @param {string} destination The host:port being navigated to (e.g. "localhost:8080")
  * @param {string} originalUrl The full original URL the user was trying to reach
+ * @param {string} [page="selectiveAllow.html"] The page within the `selectiveAllow/` directory to open
  */
-export function openSelectiveAllowPopup(origin, destination, originalUrl) {
+export function openSelectiveAllowPopup(origin, destination, originalUrl, page = "selectiveAllow.html") {
     const params = new URLSearchParams({ origin, destination, originalUrl });
     browser.windows.create({
-        url: browser.runtime.getURL(`selectiveAllow/selectiveAllow.html?${params}`),
+        url: browser.runtime.getURL(`selectiveAllow/${page}?${params}`),
         type: "popup",
         width: 500,
         height: 280,

--- a/global/browserActions.js
+++ b/global/browserActions.js
@@ -55,3 +55,19 @@ export async function getActiveTabId() {
     const tab = querying[0];
     return tab.id;
 }
+
+/**
+ * Opens the Selective Allow decision popup for a blocked cross-origin local navigation.
+ * @param {string} origin The host of the page that contained the link (e.g. "github.com")
+ * @param {string} destination The local host:port being navigated to (e.g. "localhost:8080")
+ * @param {string} originalUrl The full original URL the user was trying to reach
+ */
+export function openSelectiveAllowPopup(origin, destination, originalUrl) {
+    const params = new URLSearchParams({ origin, destination, originalUrl });
+    browser.windows.create({
+        url: browser.runtime.getURL(`selectiveAllow/selectiveAllow.html?${params}`),
+        type: "popup",
+        width: 500,
+        height: 280,
+    });
+}

--- a/selectiveAllow/localRequestSelectiveAllow.js
+++ b/selectiveAllow/localRequestSelectiveAllow.js
@@ -1,8 +1,11 @@
+// Handles the Selective Allow popup decisions for the cross-origin local request blocking feature.
+
 const params = new URLSearchParams(location.search);
 const origin = params.get("origin") ?? "unknown";
 const destination = params.get("destination") ?? "unknown";
 const originalUrl = params.get("originalUrl") ?? "";
 
+// Extract the protocol from the original URL for display
 const protocol = (() => {
     try { return new URL(originalUrl).protocol.replace(":", ""); } catch { return "unknown"; }
 })();

--- a/selectiveAllow/selectiveAllow.css
+++ b/selectiveAllow/selectiveAllow.css
@@ -1,0 +1,106 @@
+/* selectiveAllow popup — supplements common.css */
+
+body {
+    padding: 0;
+    overflow: hidden;
+    min-width: 320px;
+}
+
+header {
+    gap: 10px;
+    padding: 10px 14px;
+    flex-shrink: 0;
+}
+
+header h1 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+
+main {
+    padding: 14px 16px 16px;
+    gap: 12px;
+    flex: 1;
+}
+
+#prompt-text {
+    margin: 0;
+    font-size: 0.95rem;
+}
+
+/* Two-column definition list */
+#request-details {
+    margin: 0;
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    column-gap: 16px;
+    row-gap: 4px;
+    font-size: 0.9rem;
+}
+
+#request-details dt {
+    font-weight: 600;
+    color: var(--foreground);
+    opacity: 0.7;
+}
+
+#request-details dd {
+    margin: 0;
+    word-break: break-all;
+    user-select: text;
+}
+
+/* Action buttons row */
+#action-row {
+    gap: 8px;
+    justify-content: flex-end;
+    margin-top: 4px;
+    flex-wrap: wrap;
+}
+
+#action-row button {
+    padding: 6px 14px;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    font-size: 0.9rem;
+    cursor: pointer;
+    font-family: inherit;
+    transition: filter 0.1s;
+}
+
+#action-row button:hover {
+    filter: brightness(1.1);
+}
+
+/* Block — neutral/muted */
+#btn-block {
+    background-color: color-mix(in oklab, var(--foreground) 15%, var(--background));
+    color: var(--foreground);
+    border-color: color-mix(in oklab, var(--foreground) 30%, var(--background));
+}
+
+/* Allow Once — blue */
+#btn-allow-once {
+    background-color: #1a73e8;
+    color: #ffffff;
+}
+
+/* Always Allow — green */
+#btn-always-allow {
+    background-color: #1e8c45;
+    color: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+    #btn-allow-once {
+        background-color: #4a9eff;
+        color: #111;
+    }
+
+    #btn-always-allow {
+        background-color: #2db55d;
+        color: #111;
+    }
+}

--- a/selectiveAllow/selectiveAllow.html
+++ b/selectiveAllow/selectiveAllow.html
@@ -28,6 +28,6 @@
             <button id="btn-always-allow">Always Allow</button>
         </div>
     </main>
-    <script type="module" src="./selectiveAllow.js"></script>
+    <script type="module" src="./localRequestSelectiveAllow.js"></script>
 </body>
 </html>

--- a/selectiveAllow/selectiveAllow.html
+++ b/selectiveAllow/selectiveAllow.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="color-scheme" content="light dark">
+    <title>Port Authority — Access Request</title>
+    <link rel="stylesheet" type="text/css" href="../global/common.css">
+    <link rel="stylesheet" type="text/css" href="./selectiveAllow.css">
+</head>
+<body class="flex-column">
+    <header class="flex-row red-bg">
+        <img src="../icons/logo-32.png" width="32" height="32" alt="Port Authority Logo">
+        <h1>Port Authority</h1>
+    </header>
+    <main class="flex-column">
+        <p id="prompt-text">A page on the internet wants to navigate to a local address.</p>
+        <dl id="request-details">
+            <dt>From</dt>
+            <dd id="detail-origin">—</dd>
+            <dt>To</dt>
+            <dd id="detail-destination">—</dd>
+            <dt>Protocol</dt>
+            <dd id="detail-protocol">—</dd>
+        </dl>
+        <div id="action-row" class="flex-row">
+            <button id="btn-block">Block</button>
+            <button id="btn-allow-once">Allow Once</button>
+            <button id="btn-always-allow">Always Allow</button>
+        </div>
+    </main>
+    <script type="module" src="./selectiveAllow.js"></script>
+</body>
+</html>

--- a/selectiveAllow/selectiveAllow.js
+++ b/selectiveAllow/selectiveAllow.js
@@ -1,0 +1,26 @@
+const params = new URLSearchParams(location.search);
+const origin = params.get("origin") ?? "unknown";
+const destination = params.get("destination") ?? "unknown";
+const originalUrl = params.get("originalUrl") ?? "";
+
+const protocol = (() => {
+    try { return new URL(originalUrl).protocol.replace(":", ""); } catch { return "unknown"; }
+})();
+
+document.getElementById("detail-origin").textContent = origin;
+document.getElementById("detail-destination").textContent = destination;
+document.getElementById("detail-protocol").textContent = protocol;
+
+document.getElementById("btn-block").addEventListener("click", () => {
+    window.close();
+});
+
+document.getElementById("btn-allow-once").addEventListener("click", () => {
+    browser.runtime.sendMessage({ type: "allowOnce", origin, destination, originalUrl });
+    window.close();
+});
+
+document.getElementById("btn-always-allow").addEventListener("click", () => {
+    browser.runtime.sendMessage({ type: "alwaysAllow", origin, destination, originalUrl });
+    window.close();
+});

--- a/settings/settings.html
+++ b/settings/settings.html
@@ -25,6 +25,12 @@
             <!-- Dynamically Populated -->
         </ul>
     </section>
+    <section id="cross_origin_section" hidden>
+        <strong>Saved Cross-Origin Local Access Permissions:</strong>
+        <ul id="cross_origin_contents" class="selectable">
+            <!-- Dynamically Populated -->
+        </ul>
+    </section>
     <script type="module" src="./settings.js"></script>
 </body>
 </html>

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -139,6 +139,7 @@ const cross_origin_wrapper = document.getElementById("cross_origin_section");
 const cross_origin_contents = document.getElementById("cross_origin_contents");
 
 function cross_origin_item(entry, abort_signal) {
+    /** Removes this entry from storage and refreshes the display */
     const remove_listener = () => {
         modifyItemInLocal("cross_origin_allowlist", [],
             (list) => list.filter(
@@ -147,8 +148,11 @@ function cross_origin_item(entry, abort_signal) {
         ).then((list) => load_cross_origin_list(list));
     };
 
+    // Main container, the label is inserted as plain text with a space
     const label = `${entry.origin} → ${entry.destination}`;
     const item = createElement("li", {}, [label, " "]);
+
+    // Button to remove the entry from the allowlist
     const remove_btn = createElement("button", {
         class: "unselectable",
         "aria-label": `Remove permission for ${label}`
@@ -159,24 +163,32 @@ function cross_origin_item(entry, abort_signal) {
 }
 
 async function load_cross_origin_list(list) {
+    // Remove all stale listeners
     if (cross_origin_remove_controller) cross_origin_remove_controller.abort();
+
+    // Make a new AbortController for all of the fresh buttons
     cross_origin_remove_controller = new AbortController();
 
+    // If not provided, fetch the cross-origin allowlist from storage
     list ??= await getItemFromLocal("cross_origin_allowlist", []);
 
+    // Clear stale contents, if any
     cross_origin_contents.replaceChildren();
 
+    // Early return, hiding wrapper if no data provided
     if (!list || list.length === 0) {
         cross_origin_wrapper.setAttribute("hidden", "");
         return;
     }
 
+    // Populate the list items
     for (const entry of list) {
         cross_origin_contents.appendChild(
             cross_origin_item(entry, cross_origin_remove_controller.signal)
         );
     }
 
+    // Unhide the container wrapper at end
     cross_origin_wrapper.removeAttribute("hidden");
 }
 

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -132,3 +132,52 @@ function allowlist_add_listener(event) {
 allowlist_add_form.addEventListener("submit", allowlist_add_listener);
 
 load_allowlist();
+
+// Populate `#cross_origin_section`
+let cross_origin_remove_controller;
+const cross_origin_wrapper = document.getElementById("cross_origin_section");
+const cross_origin_contents = document.getElementById("cross_origin_contents");
+
+function cross_origin_item(entry, abort_signal) {
+    const remove_listener = () => {
+        modifyItemInLocal("cross_origin_allowlist", [],
+            (list) => list.filter(
+                (e) => !(e.origin === entry.origin && e.destination === entry.destination)
+            )
+        ).then((list) => load_cross_origin_list(list));
+    };
+
+    const label = `${entry.origin} → ${entry.destination}`;
+    const item = createElement("li", {}, [label, " "]);
+    const remove_btn = createElement("button", {
+        class: "unselectable",
+        "aria-label": `Remove permission for ${label}`
+    }, "✕");
+    remove_btn.addEventListener("click", remove_listener, { signal: abort_signal });
+    item.appendChild(remove_btn);
+    return item;
+}
+
+async function load_cross_origin_list(list) {
+    if (cross_origin_remove_controller) cross_origin_remove_controller.abort();
+    cross_origin_remove_controller = new AbortController();
+
+    list ??= await getItemFromLocal("cross_origin_allowlist", []);
+
+    cross_origin_contents.replaceChildren();
+
+    if (!list || list.length === 0) {
+        cross_origin_wrapper.setAttribute("hidden", "");
+        return;
+    }
+
+    for (const entry of list) {
+        cross_origin_contents.appendChild(
+            cross_origin_item(entry, cross_origin_remove_controller.signal)
+        );
+    }
+
+    cross_origin_wrapper.removeAttribute("hidden");
+}
+
+load_cross_origin_list();


### PR DESCRIPTION
## Problem

When a page on the internet contains a link to a local address (e.g. `http://localhost:8080`), Port Authority blocks the navigation because `webRequest.onBeforeRequest` reports the `originUrl` as the external page, making it look like a port scan. This breaks legitimate workflows: Proxmox consoles, VPN dashboards, local dev server links in documentation, etc.

Closes #57. Supersedes #72 (which silently allowed all `main_frame` LAN navigations — closed separately).

## Solution — Selective Allow

Rather than silently blocking or silently allowing, a small popup window asks the user what to do.

**Popup shows:** external origin, local destination, protocol.

**User choices:**
| Button | Effect |
|--------|--------|
| Block | Stays blocked, nothing saved |
| Allow Once | Allowed this browser session (in-memory `Set`, clears on restart) |
| Always Allow | Saved as `{ origin, destination }` pair in new `cross_origin_allowlist` storage key |

Saved permissions can be reviewed and removed from the extension settings page.

## Scope

Only **`main_frame`** (user-initiated top-level navigations) get the popup. Sub-resource requests (`fetch`, XHR, iframes) from external origins to local addresses are still silently blocked and logged in the existing popup blocked-requests list — those are the actual port-scan vectors.

## Files changed

- `background.js` — session allow set, `main_frame` detection, `allowOnce`/`alwaysAllow` message handlers
- `global/browserActions.js` — `openSelectiveAllowPopup()` helper
- `selectiveAllow/` — new popup page (`.html`, `.js`, `.css`)
- `settings/settings.html` + `settings/settings.js` — UI to manage saved `cross_origin_allowlist` entries
- `README.md` — Selective Allow feature documentation