### PR TITLE
Improve DNS rebinding fix with IPv6 private range checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ This addon blocks websites from using javascript to port scan your computer/inte
 ## Donations
 - Monero Address: `89jYJvX3CaFNv1T6mhg69wK5dMQJSF3aG2AYRNU1ZSo6WbccGtJN7TNMAf39vrmKNR6zXUKxJVABggR4a8cZDGST11Q4yS8`
 
-## Regex Explanation
-- Explanation of the regex used to determine local addresses: https://regex101.com/r/LSL180/1
-- Explanation of the regex which is used to match the protocol: https://regex101.com/r/f8LSTx/2
+## Implementation Notes
+- Local address detection uses the URL API and `global/privateAddress.js` (RFC 1918, loopback, link-local, IPv6 ULA, and exact `localhost` hostname matching)
+- Explanation of the regex used to match ThreatMetrix CNAMEs: https://regex101.com/r/f8LSTx/2
 
 ## Test All Forms of Port Scanning 
 - A webpage I made to test all forms of scanning in one location using the [./TestPortScans.html](https://github.com/ACK-J/Port_Authority/blob/main/TestPortScans.html) file

--- a/background.js
+++ b/background.js
@@ -20,6 +20,20 @@ const local_filter = new RegExp("\\b(^(http|https|wss|ws|ftp|ftps):\/\/127[.](?:
 // Create a regex to find all sub-domains for online-metrix.net  Explained here https://regex101.com/r/f8LSTx/2
 const thm = new RegExp("online-metrix[.]net$", "i");
 
+function isPrivateIPv4(ip) {
+    const parts = ip.split(".").map(Number);
+    if (parts.length !== 4 || parts.some(isNaN)) return false;
+    const [a, b] = parts;
+    return (
+        a === 127 ||
+        a === 10 ||
+        (a === 172 && b >= 16 && b <= 31) ||
+        (a === 192 && b === 168) ||
+        (a === 169 && b === 254) ||
+        (a === 0 && parts.every(p => p === 0))
+    );
+}
+
 async function cancel(requestDetails) {
     // First check if it's a same-origin request
     if(!requestDetails.thirdParty) {
@@ -64,13 +78,29 @@ async function cancel(requestDetails) {
         return { cancel: true };
     }
 
-    // The early return in the if case above makes sure we are not searching the CNAME of local addresses
-    // Send a request to get the CNAME of the webrequest
-    const resolving = await browser.dns.resolve(url.host, ["canonical_name"]);
-    // If the CNAME redirects to a online-metrix.net domain -> Block
+    // Resolve hostname once; check both private-IP and ThreatMetrix CNAME.
+    let resolving;
+    try {
+        resolving = await browser.dns.resolve(url.host, ["canonical_name"]);
+    } catch (e) {
+        // Fail open — DNS failure should not break valid but temporarily
+        // unresolvable domains (captive portals, split-horizon DNS, etc.)
+        console.warn("DNS resolution failed for:", url.host, e);
+        return { cancel: false };
+    }
+
+    for (const address of resolving.addresses ?? []) {
+        if (isPrivateIPv4(address)) {
+            console.debug("Blocking domain: DNS resolved to private IP:", { url, address });
+            increaseBadge(requestDetails, false);
+            addBlockedPortToHost(url, requestDetails.tabId);
+            return { cancel: true };
+        }
+    }
+
     if (thm.test(resolving.canonicalName)) {
-        console.debug("Blocking domain for being a threatmetrix match: ", {url: url, cname: resolving.canonicalName});
-        increaseBadge(requestDetails, true); // increment badge and alert
+        console.debug("Blocking domain for ThreatMetrix CNAME:", { url, cname: resolving.canonicalName });
+        increaseBadge(requestDetails, true);
         addBlockedTrackingHost(url, requestDetails.tabId);
         return { cancel: true };
     }

--- a/background.js
+++ b/background.js
@@ -1,6 +1,6 @@
 import { getItemFromLocal, setItemInLocal, modifyItemInLocal,
     addBlockedPortToHost, addBlockedTrackingHost, increaseBadge } from "./global/BrowserStorageManager.js";
-import { isPrivateAddress } from "./global/privateAddress.js";
+import { isLocalRequestUrl, isPrivateAddress } from "./global/privateAddress.js";
 
 async function startup(){
     // No need to check and initialize notification, state, and allow list values as they will 
@@ -16,8 +16,6 @@ async function startup(){
 	}
 }
 
-// This regex is explained here https://regex101.com/r/LSL180/1 below I needed to change \b -> \\b
-const local_filter = new RegExp("\\b(^(http|https|wss|ws|ftp|ftps):\/\/127[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|^(http|https|wss|ws|ftp|ftps):\/\/0.0.0.0|^(http|https|wss|ws|ftp|ftps):\/\/(10)([.](25[0-5]|2[0-4][0-9]|1[0-9]{1,2}|[0-9]{1,2})){3}|^(http|https|wss|ws|ftp|ftps):\/\/localhost|^(http|https|wss|ws|ftp|ftps):\/\/172[.](0?16|0?17|0?18|0?19|0?20|0?21|0?22|0?23|0?24|0?25|0?26|0?27|0?28|0?29|0?30|0?31)[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|^(http|https|wss|ws|ftp|ftps):\/\/192[.]168[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|^(http|https|wss|ws|ftp|ftps):\/\/169[.]254[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))(?:\/([789]|1?[0-9]{2}))?\\b", "i");
 // Create a regex to find all sub-domains for online-metrix.net  Explained here https://regex101.com/r/f8LSTx/2
 const thm = new RegExp("online-metrix[.]net$", "i");
 
@@ -57,7 +55,7 @@ async function cancel(requestDetails) {
     }
 
     // Local request check
-    if (local_filter.test(requestDetails.url)) {
+    if (isLocalRequestUrl(url)) {
         // The network request is going to a local address and has already failed a same-origin check, block it
         console.debug("Blocking domain for portscanning: ", url);
         increaseBadge(requestDetails, false); // increment badge and alert

--- a/background.js
+++ b/background.js
@@ -1,5 +1,6 @@
 import { getItemFromLocal, setItemInLocal, modifyItemInLocal,
     addBlockedPortToHost, addBlockedTrackingHost, increaseBadge } from "./global/BrowserStorageManager.js";
+import { isPrivateAddress } from "./global/privateAddress.js";
 
 async function startup(){
     // No need to check and initialize notification, state, and allow list values as they will 
@@ -19,20 +20,6 @@ async function startup(){
 const local_filter = new RegExp("\\b(^(http|https|wss|ws|ftp|ftps):\/\/127[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|^(http|https|wss|ws|ftp|ftps):\/\/0.0.0.0|^(http|https|wss|ws|ftp|ftps):\/\/(10)([.](25[0-5]|2[0-4][0-9]|1[0-9]{1,2}|[0-9]{1,2})){3}|^(http|https|wss|ws|ftp|ftps):\/\/localhost|^(http|https|wss|ws|ftp|ftps):\/\/172[.](0?16|0?17|0?18|0?19|0?20|0?21|0?22|0?23|0?24|0?25|0?26|0?27|0?28|0?29|0?30|0?31)[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|^(http|https|wss|ws|ftp|ftps):\/\/192[.]168[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|^(http|https|wss|ws|ftp|ftps):\/\/169[.]254[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[.](?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))(?:\/([789]|1?[0-9]{2}))?\\b", "i");
 // Create a regex to find all sub-domains for online-metrix.net  Explained here https://regex101.com/r/f8LSTx/2
 const thm = new RegExp("online-metrix[.]net$", "i");
-
-function isPrivateIPv4(ip) {
-    const parts = ip.split(".").map(Number);
-    if (parts.length !== 4 || parts.some(isNaN)) return false;
-    const [a, b] = parts;
-    return (
-        a === 127 ||
-        a === 10 ||
-        (a === 172 && b >= 16 && b <= 31) ||
-        (a === 192 && b === 168) ||
-        (a === 169 && b === 254) ||
-        (a === 0 && parts.every(p => p === 0))
-    );
-}
 
 async function cancel(requestDetails) {
     // First check if it's a same-origin request
@@ -66,8 +53,8 @@ async function cancel(requestDetails) {
         url = new URL(requestDetails.url);
     } catch(error) {
         console.error("Error filtering on domain due to unparseable request URL: ", requestDetails.url, error);
+        return { cancel: false };
     }
-
 
     // Local request check
     if (local_filter.test(requestDetails.url)) {
@@ -90,8 +77,8 @@ async function cancel(requestDetails) {
     }
 
     for (const address of resolving.addresses ?? []) {
-        if (isPrivateIPv4(address)) {
-            console.debug("Blocking domain: DNS resolved to private IP:", { url, address });
+        if (isPrivateAddress(address)) {
+            console.debug("Blocking domain: DNS resolved to private address:", { url, address });
             increaseBadge(requestDetails, false);
             addBlockedPortToHost(url, requestDetails.tabId);
             return { cancel: true };

--- a/background.js
+++ b/background.js
@@ -1,6 +1,6 @@
 import { getItemFromLocal, setItemInLocal, modifyItemInLocal,
     addBlockedPortToHost, addBlockedTrackingHost, increaseBadge } from "./global/BrowserStorageManager.js";
-import { isLocalRequestUrl, isPrivateAddress } from "./global/privateAddress.js";
+import { isLocalRequestUrl, isLiteralIpHostname, isPrivateAddress } from "./global/privateAddress.js";
 
 async function startup(){
     // No need to check and initialize notification, state, and allow list values as they will 
@@ -18,6 +18,12 @@ async function startup(){
 
 // Create a regex to find all sub-domains for online-metrix.net  Explained here https://regex101.com/r/f8LSTx/2
 const thm = new RegExp("online-metrix[.]net$", "i");
+
+function blockPortScan(requestDetails, url) {
+    increaseBadge(requestDetails, false);
+    addBlockedPortToHost(url, requestDetails.tabId);
+    return { cancel: true };
+}
 
 async function cancel(requestDetails) {
     // First check if it's a same-origin request
@@ -54,32 +60,32 @@ async function cancel(requestDetails) {
         return { cancel: false };
     }
 
-    // Local request check
+    // Local request check — literal private hostnames/IPs in the URL
     if (isLocalRequestUrl(url)) {
-        // The network request is going to a local address and has already failed a same-origin check, block it
         console.debug("Blocking domain for portscanning: ", url);
-        increaseBadge(requestDetails, false); // increment badge and alert
-        addBlockedPortToHost(url, requestDetails.tabId);
-        return { cancel: true };
+        return blockPortScan(requestDetails, url);
     }
 
-    // Resolve hostname once; check both private-IP and ThreatMetrix CNAME.
+    // Domain names may resolve to private addresses (DNS rebinding). Literal IP
+    // hostnames were already checked above; skip DNS for public IP literals.
+    if (isLiteralIpHostname(url.hostname)) {
+        return { cancel: false };
+    }
+
     let resolving;
     try {
-        resolving = await browser.dns.resolve(url.host, ["canonical_name"]);
+        resolving = await browser.dns.resolve(url.hostname, ["canonical_name"]);
     } catch (e) {
         // Fail open — DNS failure should not break valid but temporarily
         // unresolvable domains (captive portals, split-horizon DNS, etc.)
-        console.warn("DNS resolution failed for:", url.host, e);
+        console.warn("DNS resolution failed for:", url.hostname, e);
         return { cancel: false };
     }
 
     for (const address of resolving.addresses ?? []) {
         if (isPrivateAddress(address)) {
             console.debug("Blocking domain: DNS resolved to private address:", { url, address });
-            increaseBadge(requestDetails, false);
-            addBlockedPortToHost(url, requestDetails.tabId);
-            return { cancel: true };
+            return blockPortScan(requestDetails, url);
         }
     }
 

--- a/global/privateAddress.js
+++ b/global/privateAddress.js
@@ -71,6 +71,13 @@ function normalizeHostname(hostname) {
     return host.toLowerCase();
 }
 
+/** True when `hostname` is an IPv4/IPv6 literal (not a domain name). */
+export function isLiteralIpHostname(hostname) {
+    const host = normalizeHostname(hostname);
+    if (host.includes(":")) return true;
+    return /^\d+\.\d+\.\d+\.\d+$/.test(host);
+}
+
 /**
  * Returns true when `url` targets a local/private address over a supported protocol.
  * @param {URL} url Parsed request URL

--- a/global/privateAddress.js
+++ b/global/privateAddress.js
@@ -1,7 +1,11 @@
 /**
- * Detects IP addresses in non-routable/private ranges that local_filter would
- * block when they appear literally in a request URL.
+ * Detects when a network request targets a non-routable/local address.
+ * Uses the URL API for parsing instead of regex on raw URL strings.
  */
+
+const LOCAL_REQUEST_PROTOCOLS = new Set([
+    "http:", "https:", "ws:", "wss:", "ftp:", "ftps:",
+]);
 
 function isPrivateIPv4(ip) {
     const parts = ip.split(".").map(Number);
@@ -54,4 +58,28 @@ export function isPrivateAddress(ip) {
     if (ip.includes(":")) return isPrivateIPv6(ip);
     if (ip.includes(".")) return isPrivateIPv4(ip);
     return false;
+}
+
+function normalizeHostname(hostname) {
+    let host = hostname;
+    if (host.startsWith("[") && host.endsWith("]")) {
+        host = host.slice(1, -1);
+    }
+    if (host.endsWith(".")) {
+        host = host.slice(0, -1);
+    }
+    return host.toLowerCase();
+}
+
+/**
+ * Returns true when `url` targets a local/private address over a supported protocol.
+ * @param {URL} url Parsed request URL
+ */
+export function isLocalRequestUrl(url) {
+    if (!LOCAL_REQUEST_PROTOCOLS.has(url.protocol)) return false;
+
+    const hostname = normalizeHostname(url.hostname);
+    if (hostname === "localhost") return true;
+
+    return isPrivateAddress(hostname);
 }

--- a/global/privateAddress.js
+++ b/global/privateAddress.js
@@ -1,0 +1,57 @@
+/**
+ * Detects IP addresses in non-routable/private ranges that local_filter would
+ * block when they appear literally in a request URL.
+ */
+
+function isPrivateIPv4(ip) {
+    const parts = ip.split(".").map(Number);
+    if (parts.length !== 4 || parts.some((n) => Number.isNaN(n))) return false;
+    const [a, b] = parts;
+    return (
+        a === 127 ||
+        a === 10 ||
+        (a === 172 && b >= 16 && b <= 31) ||
+        (a === 192 && b === 168) ||
+        (a === 169 && b === 254) ||
+        (a === 0 && parts.every((p) => p === 0))
+    );
+}
+
+function parseIPv4MappedSuffix(normalized) {
+    const shortForm = normalized.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/);
+    if (shortForm) return shortForm[1];
+
+    const longForm = normalized.match(/(?:^|:)(?:0+:){0,5}ffff:(\d{1,3}(?:\.\d{1,3}){3})$/);
+    if (longForm) return longForm[1];
+
+    return null;
+}
+
+function isPrivateIPv6(ip) {
+    const normalized = ip.toLowerCase().split("%")[0];
+
+    if (normalized === "::1" || normalized === "0:0:0:0:0:0:0:1") {
+        return true;
+    }
+
+    const mapped = parseIPv4MappedSuffix(normalized);
+    if (mapped) return isPrivateIPv4(mapped);
+
+    const firstSegment = normalized.split(":").find((segment) => segment.length > 0);
+    if (!firstSegment) return false;
+
+    const firstHextet = parseInt(firstSegment, 16);
+    if (Number.isNaN(firstHextet)) return false;
+
+    // fe80::/10 link-local, fc00::/7 unique local (ULA)
+    return (
+        (firstHextet >= 0xfe80 && firstHextet <= 0xfebf) ||
+        (firstHextet >= 0xfc00 && firstHextet <= 0xfdff)
+    );
+}
+
+export function isPrivateAddress(ip) {
+    if (ip.includes(":")) return isPrivateIPv6(ip);
+    if (ip.includes(".")) return isPrivateIPv4(ip);
+    return false;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Builds on [#73](https://github.com/ACK-J/Port_Authority/pull/73) to close the DNS rebinding bypass ([#69](https://github.com/ACK-J/Port_Authority/issues/69)).

## Changes

- **Replace `local_filter` regex with URL parsing** — `isLocalRequestUrl()` uses the URL API and `global/privateAddress.js` instead of regex-matching raw URL strings.
- **DNS rebinding protection** — resolve domain hostnames via `browser.dns.resolve()` and block when any address is private.
- **IPv6 coverage** — loopback (`::1`), link-local (`fe80::/10`), ULA (`fc00::/7`), IPv4-mapped private addresses.
- **Safer hostname handling** — exact `localhost` matching (excludes `localhost.example.com`), trailing-dot FQDN normalization, browser-normalized IPv4 forms.
- **Fix `url.hostname` for DNS** — use `url.hostname` (not `url.host`) so URLs with ports like `http://example.com:8080` resolve correctly.
- **Skip DNS for literal IPs** — public IP literals skip redundant DNS lookups; private literals are caught by `isLocalRequestUrl()`.

## Review fixes (latest)

| Issue | Fix |
|-------|-----|
| `browser.dns.resolve(url.host)` included port, causing fail-open | Changed to `url.hostname` |
| Redundant DNS on `http://8.8.8.8` | Skip DNS when hostname is a literal IP |
| Duplicated block logic | Extracted `blockPortScan()` helper |

## Behavior improvements over old regex

| URL | Old regex | This PR |
|-----|-----------|---------|
| `http://localhost.example.com` | blocked (false positive) | allowed |
| `http://[::1]:8080` | missed | blocked |
| `http://localtest.me` (DNS→127.0.0.1) | missed | blocked |
| `http://rebinding.local:8080` via `/etc/hosts`→192.168.1.1 | missed | blocked |

## Testing

```bash
# Unit checks
node --input-type=module -e "import { isLocalRequestUrl, isPrivateAddress } from './global/privateAddress.js'; ..."

# Manual (Firefox): load temp add-on, from external page console:
fetch('http://localtest.me').catch(() => {});
# → extension popup badge increases, background log: "DNS resolved to private address"
```

Closes #69. Supersedes [#73](https://github.com/ACK-J/Port_Authority/pull/73).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4f67-98c3-7fcd-bccd-a3e2b55792ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4f67-98c3-7fcd-bccd-a3e2b55792ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

