### PR TITLE
Fix allowlist to honor IP addresses and CIDR ranges

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,6 +1,6 @@
 import { getItemFromLocal, setItemInLocal, modifyItemInLocal,
     addBlockedPortToHost, addBlockedTrackingHost, increaseBadge } from "./global/BrowserStorageManager.js";
-import { hostMatchesAllowlistEntry } from "./global/hostUtils.js";
+import { requestMatchesAllowlist } from "./global/hostUtils.js";
 
 async function startup(){
     // No need to check and initialize notification, state, and allow list values as they will 
@@ -38,12 +38,24 @@ async function cancel(requestDetails) {
         return { cancel: false }; // invalid origin
     }
     const allowed_domains_list = await getItemFromLocal("allowed_domain_list", []);
-    // Exact match for domains; IP entries without a port match any port on that address
-    const domainIsWhiteListed = allowed_domains_list.some(
-        (entry) => hostMatchesAllowlistEntry(check_allowed_url.host, entry)
+
+    let requestHost;
+    try {
+        requestHost = new URL(requestDetails.url).host;
+    } catch {
+        requestHost = null;
+    }
+
+    const requestIsAllowlisted = requestMatchesAllowlist(
+        check_allowed_url.host,
+        requestHost,
+        allowed_domains_list
     );
-    if (domainIsWhiteListed){
-        console.debug("Aborted filtering on host due to whitelist: ", check_allowed_url);
+    if (requestIsAllowlisted){
+        console.debug("Aborted filtering on host due to whitelist: ", {
+            origin: check_allowed_url,
+            requestHost
+        });
         return { cancel: false };
     }
 

--- a/background.js
+++ b/background.js
@@ -1,5 +1,6 @@
 import { getItemFromLocal, setItemInLocal, modifyItemInLocal,
     addBlockedPortToHost, addBlockedTrackingHost, increaseBadge } from "./global/BrowserStorageManager.js";
+import { hostMatchesAllowlistEntry } from "./global/hostUtils.js";
 
 async function startup(){
     // No need to check and initialize notification, state, and allow list values as they will 
@@ -37,12 +38,12 @@ async function cancel(requestDetails) {
         return { cancel: false }; // invalid origin
     }
     const allowed_domains_list = await getItemFromLocal("allowed_domain_list", []);
-    // Perform an exact match against the whitelisted domains (dont assume subdomains are allowed)
+    // Exact match for domains; IP entries without a port match any port on that address
     const domainIsWhiteListed = allowed_domains_list.some(
-        (domain) => check_allowed_url.host === domain
+        (entry) => hostMatchesAllowlistEntry(check_allowed_url.host, entry)
     );
     if (domainIsWhiteListed){
-        console.debug("Aborted filtering on domain due to whitelist: ", check_allowed_url);
+        console.debug("Aborted filtering on host due to whitelist: ", check_allowed_url);
         return { cancel: false };
     }
 

--- a/global/hostUtils.js
+++ b/global/hostUtils.js
@@ -1,25 +1,111 @@
+const IPV4_PATTERN = /^(?:\d{1,3}\.){3}\d{1,3}$/;
+
 /**
  * Returns whether a URL hostname represents an IP address (IPv4 or IPv6).
  * @param {string} hostname A URL.hostname value (IPv6 may include brackets)
  */
 export function isIPAddress(hostname) {
     const bare = hostname.startsWith("[") ? hostname.slice(1, -1) : hostname;
-    if (/^(?:\d{1,3}\.){3}\d{1,3}$/.test(bare)) {
+    if (IPV4_PATTERN.test(bare)) {
         return true;
     }
     return bare.includes(":");
 }
 
 /**
+ * Returns whether an allowlist entry uses CIDR notation.
+ * @param {string} entry
+ */
+export function isCIDRAllowlistEntry(entry) {
+    const slashIndex = entry.lastIndexOf("/");
+    if (slashIndex <= 0 || slashIndex === entry.length - 1) {
+        return false;
+    }
+
+    const network = entry.slice(0, slashIndex);
+    const prefix = Number(entry.slice(slashIndex + 1));
+    if (!Number.isInteger(prefix)) {
+        return false;
+    }
+
+    const bareNetwork = network.startsWith("[") ? network.slice(1, -1) : network;
+    if (IPV4_PATTERN.test(bareNetwork)) {
+        return prefix >= 0 && prefix <= 32 && ipv4ToInt(bareNetwork) !== null;
+    }
+
+    return prefix >= 0 && prefix <= 128 && ipv6ToBigInt(bareNetwork) !== null;
+}
+
+/**
+ * Get a well-formed host to match against from a user-supplied URL.
+ * @param {string} url A URL-like value
+ * @returns {string} Well formatted host portion of url
+ * @throws When parsing an invalid URL
+ */
+export function extractURLHost(url) {
+    url = url.trim();
+
+    if (!url.match(/^\w*:\/\//)) {
+        const pathStart = url.indexOf("/");
+        const hostPort = pathStart === -1 ? url : url.slice(0, pathStart);
+        const path = pathStart === -1 ? "" : url.slice(pathStart);
+
+        if (hostPort.includes(":") && !hostPort.startsWith("[")) {
+            const isIPv4WithOptionalPort = /^(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?$/.test(hostPort);
+            url = isIPv4WithOptionalPort ?
+                `http://${hostPort}${path}` :
+                `http://[${hostPort}]${path}`;
+        } else {
+            url = `http://${url}`;
+        }
+    }
+
+    return new URL(url).host;
+}
+
+/**
+ * Normalize and validate a user-supplied allowlist entry.
+ * @param {string} input
+ * @returns {string}
+ * @throws When the entry is invalid
+ */
+export function normalizeAllowlistEntry(input) {
+    input = input.trim();
+    if (!input) {
+        throw new Error("empty allowlist entry");
+    }
+
+    if (input.includes("/")) {
+        if (!isCIDRAllowlistEntry(input)) {
+            throw new Error("invalid CIDR notation");
+        }
+        return input;
+    }
+
+    return extractURLHost(input);
+}
+
+/**
  * Returns whether an origin host matches an allowlist entry.
  * Domains require an exact host match. IP addresses without an explicit port
  * also match the same address on any port (e.g. 127.0.0.1 matches 127.0.0.1:8080).
+ * CIDR entries match any origin IP within the range.
  * @param {string} originHost A URL.host value from the request origin
  * @param {string} allowlistEntry A stored allowlist entry
  */
 export function hostMatchesAllowlistEntry(originHost, allowlistEntry) {
     if (originHost === allowlistEntry) {
         return true;
+    }
+
+    if (isCIDRAllowlistEntry(allowlistEntry)) {
+        let originHostname;
+        try {
+            originHostname = new URL(`http://${originHost}/`).hostname;
+        } catch {
+            return false;
+        }
+        return ipInCIDR(originHostname, allowlistEntry);
     }
 
     let originUrl;
@@ -33,6 +119,102 @@ export function hostMatchesAllowlistEntry(originHost, allowlistEntry) {
 
     if (entryUrl.host === entryUrl.hostname && isIPAddress(entryUrl.hostname)) {
         return originUrl.hostname === entryUrl.hostname;
+    }
+
+    return false;
+}
+
+function ipv4ToInt(ip) {
+    const parts = ip.split(".").map((part) => Number(part));
+    if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+        return null;
+    }
+    return ((parts[0] << 24) >>> 0) + (parts[1] << 16) + (parts[2] << 8) + parts[3];
+}
+
+function expandIPv6(ip) {
+    const bare = ip.replace(/^\[|\]$/g, "");
+    if (!bare.includes("::")) {
+        const groups = bare.split(":");
+        if (groups.length !== 8) {
+            return null;
+        }
+        return groups;
+    }
+
+    const [head, tail] = bare.split("::");
+    const headGroups = head ? head.split(":").filter(Boolean) : [];
+    const tailGroups = tail ? tail.split(":").filter(Boolean) : [];
+    const missing = 8 - headGroups.length - tailGroups.length;
+    if (missing < 0) {
+        return null;
+    }
+
+    return [...headGroups, ...Array(missing).fill("0"), ...tailGroups];
+}
+
+function ipv6ToBigInt(ip) {
+    const groups = expandIPv6(ip);
+    if (!groups) {
+        return null;
+    }
+
+    let value = 0n;
+    for (const group of groups) {
+        if (!/^[0-9a-f]{1,4}$/i.test(group)) {
+            return null;
+        }
+        const part = Number.parseInt(group, 16);
+        if (part < 0 || part > 0xffff) {
+            return null;
+        }
+        value = (value << 16n) + BigInt(part);
+    }
+
+    return value;
+}
+
+function ipv4InCIDR(ip, cidr) {
+    const slashIndex = cidr.lastIndexOf("/");
+    const network = cidr.slice(0, slashIndex);
+    const prefix = Number(cidr.slice(slashIndex + 1));
+    const ipInt = ipv4ToInt(ip);
+    const networkInt = ipv4ToInt(network);
+    if (ipInt === null || networkInt === null || prefix < 0 || prefix > 32) {
+        return false;
+    }
+
+    const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0;
+    return (ipInt & mask) === (networkInt & mask);
+}
+
+function ipv6InCIDR(ip, cidr) {
+    const slashIndex = cidr.lastIndexOf("/");
+    const network = cidr.slice(0, slashIndex);
+    const prefix = Number(cidr.slice(slashIndex + 1));
+    const ipBig = ipv6ToBigInt(ip);
+    const networkBig = ipv6ToBigInt(network);
+    if (ipBig === null || networkBig === null || prefix < 0 || prefix > 128) {
+        return false;
+    }
+
+    const mask = prefix === 0 ?
+        0n :
+        ((1n << 128n) - 1n) << BigInt(128 - prefix);
+    return (ipBig & mask) === (networkBig & mask);
+}
+
+function ipInCIDR(ip, cidr) {
+    const bareIp = ip.replace(/^\[|\]$/g, "");
+    const slashIndex = cidr.lastIndexOf("/");
+    const network = cidr.slice(0, slashIndex).replace(/^\[|\]$/g, "");
+
+    if (IPV4_PATTERN.test(bareIp) && IPV4_PATTERN.test(network)) {
+        return ipv4InCIDR(bareIp, cidr);
+    }
+
+    if (bareIp.includes(":") && network.includes(":")) {
+        return ipv6InCIDR(bareIp, cidr);
     }
 
     return false;

--- a/global/hostUtils.js
+++ b/global/hostUtils.js
@@ -1,0 +1,39 @@
+/**
+ * Returns whether a URL hostname represents an IP address (IPv4 or IPv6).
+ * @param {string} hostname A URL.hostname value (IPv6 may include brackets)
+ */
+export function isIPAddress(hostname) {
+    const bare = hostname.startsWith("[") ? hostname.slice(1, -1) : hostname;
+    if (/^(?:\d{1,3}\.){3}\d{1,3}$/.test(bare)) {
+        return true;
+    }
+    return bare.includes(":");
+}
+
+/**
+ * Returns whether an origin host matches an allowlist entry.
+ * Domains require an exact host match. IP addresses without an explicit port
+ * also match the same address on any port (e.g. 127.0.0.1 matches 127.0.0.1:8080).
+ * @param {string} originHost A URL.host value from the request origin
+ * @param {string} allowlistEntry A stored allowlist entry
+ */
+export function hostMatchesAllowlistEntry(originHost, allowlistEntry) {
+    if (originHost === allowlistEntry) {
+        return true;
+    }
+
+    let originUrl;
+    let entryUrl;
+    try {
+        originUrl = new URL(`http://${originHost}/`);
+        entryUrl = new URL(`http://${allowlistEntry}/`);
+    } catch {
+        return false;
+    }
+
+    if (entryUrl.host === entryUrl.hostname && isIPAddress(entryUrl.hostname)) {
+        return originUrl.hostname === entryUrl.hostname;
+    }
+
+    return false;
+}

--- a/global/hostUtils.js
+++ b/global/hostUtils.js
@@ -1,5 +1,42 @@
 const IPV4_PATTERN = /^(?:\d{1,3}\.){3}\d{1,3}$/;
 
+function hostnameFromHost(host) {
+    try {
+        return new URL(`http://${host}/`).hostname;
+    } catch {
+        return host;
+    }
+}
+
+/**
+ * Treat localhost hostnames as 127.0.0.1 for allowlist comparisons.
+ * @param {string} hostname
+ */
+function normalizeLoopbackHostname(hostname) {
+    const bare = hostname.replace(/^\[|\]$/g, "").toLowerCase().replace(/\.$/, "");
+    if (bare === "localhost") {
+        return "127.0.0.1";
+    }
+    return bare;
+}
+
+/**
+ * Returns whether an allowlist entry refers to an IP address or CIDR range.
+ * @param {string} entry
+ */
+export function isIPOrCIDREntry(entry) {
+    if (isCIDRAllowlistEntry(entry)) {
+        return true;
+    }
+
+    try {
+        const entryUrl = new URL(`http://${entry}/`);
+        return entryUrl.host === entryUrl.hostname && isIPAddress(entryUrl.hostname);
+    } catch {
+        return false;
+    }
+}
+
 /**
  * Returns whether a URL hostname represents an IP address (IPv4 or IPv6).
  * @param {string} hostname A URL.hostname value (IPv6 may include brackets)
@@ -99,12 +136,7 @@ export function hostMatchesAllowlistEntry(originHost, allowlistEntry) {
     }
 
     if (isCIDRAllowlistEntry(allowlistEntry)) {
-        let originHostname;
-        try {
-            originHostname = new URL(`http://${originHost}/`).hostname;
-        } catch {
-            return false;
-        }
+        const originHostname = normalizeLoopbackHostname(hostnameFromHost(originHost));
         return ipInCIDR(originHostname, allowlistEntry);
     }
 
@@ -117,11 +149,36 @@ export function hostMatchesAllowlistEntry(originHost, allowlistEntry) {
         return false;
     }
 
+    const originHostname = normalizeLoopbackHostname(originUrl.hostname);
+    const entryHostname = normalizeLoopbackHostname(entryUrl.hostname);
+
     if (entryUrl.host === entryUrl.hostname && isIPAddress(entryUrl.hostname)) {
-        return originUrl.hostname === entryUrl.hostname;
+        return originHostname === entryHostname;
     }
 
     return false;
+}
+
+/**
+ * Returns whether a request should bypass blocking based on the allowlist.
+ * Domain entries only match the page origin. IP and CIDR entries also match
+ * local/private scan destinations so trusted addresses can be reached.
+ * @param {string} originHost A URL.host value from the request origin
+ * @param {string|null|undefined} requestHost A URL.host value for the request target
+ * @param {string[]} allowlist
+ */
+export function requestMatchesAllowlist(originHost, requestHost, allowlist) {
+    return allowlist.some((entry) => {
+        if (hostMatchesAllowlistEntry(originHost, entry)) {
+            return true;
+        }
+
+        if (!requestHost || !isIPOrCIDREntry(entry)) {
+            return false;
+        }
+
+        return hostMatchesAllowlistEntry(requestHost, entry);
+    });
 }
 
 function ipv4ToInt(ip) {

--- a/settings/settings.html
+++ b/settings/settings.html
@@ -13,14 +13,14 @@
 
 <body class="flex-column">
     <form id="allowlist_add_form">
-        <p><strong class="warning-text">Make sure you enter a proper domain name (discord.com)</strong></p>
-        <label>Allow new domain:
-            <input type="text" name="add_domain" required placeholder="discord.com (example)">
+        <p><strong class="warning-text">Enter a domain (discord.com) or IP address (127.0.0.1)</strong></p>
+        <label>Allow new domain or IP address:
+            <input type="text" name="add_domain" required placeholder="discord.com or 127.0.0.1">
         </label>
         <button type="submit">Add</button>
     </form>
     <section id="allowlist_section" hidden>
-        <strong>Domains Allowed to Bypass PortAuthority Blocking:</strong>
+        <strong>Domains and IP Addresses Allowed to Bypass PortAuthority Blocking:</strong>
         <ul id="allowlist_contents" class="selectable">
             <!-- Dynamically Populated -->
         </ul>

--- a/settings/settings.html
+++ b/settings/settings.html
@@ -13,14 +13,14 @@
 
 <body class="flex-column">
     <form id="allowlist_add_form">
-        <p><strong class="warning-text">Enter a domain (discord.com) or IP address (127.0.0.1)</strong></p>
-        <label>Allow new domain or IP address:
-            <input type="text" name="add_domain" required placeholder="discord.com or 127.0.0.1">
+        <p><strong class="warning-text">Enter a domain (discord.com), IP address (127.0.0.1), or CIDR range (192.168.1.0/24)</strong></p>
+        <label>Allow new domain, IP address, or CIDR range:
+            <input type="text" name="add_domain" required placeholder="discord.com, 127.0.0.1, or 192.168.1.0/24">
         </label>
         <button type="submit">Add</button>
     </form>
     <section id="allowlist_section" hidden>
-        <strong>Domains and IP Addresses Allowed to Bypass PortAuthority Blocking:</strong>
+        <strong>Domains, IP Addresses, and CIDR Ranges Allowed to Bypass PortAuthority Blocking:</strong>
         <ul id="allowlist_contents" class="selectable">
             <!-- Dynamically Populated -->
         </ul>

--- a/settings/settings.html
+++ b/settings/settings.html
@@ -14,6 +14,7 @@
 <body class="flex-column">
     <form id="allowlist_add_form">
         <p><strong class="warning-text">Enter a domain (discord.com), IP address (127.0.0.1), or CIDR range (192.168.1.0/24)</strong></p>
+        <p>Domains match the page making the request. IP and CIDR entries also allow connections to those addresses.</p>
         <label>Allow new domain, IP address, or CIDR range:
             <input type="text" name="add_domain" required placeholder="discord.com, 127.0.0.1, or 192.168.1.0/24">
         </label>

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -89,7 +89,18 @@ function extractURLHost(url) {
     // We don't actually care about the protocol as we only compare url.host
     // But the URL object will fail to create if no protocol is provided
     if (!url.match(/^\w*:\/\//)) {
-        url = "http://" + url;
+        const pathStart = url.indexOf("/");
+        const hostPort = pathStart === -1 ? url : url.slice(0, pathStart);
+        const path = pathStart === -1 ? "" : url.slice(pathStart);
+
+        if (hostPort.includes(":") && !hostPort.startsWith("[")) {
+            const isIPv4WithOptionalPort = /^(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?$/.test(hostPort);
+            url = isIPv4WithOptionalPort ?
+                `http://${hostPort}${path}` :
+                `http://[${hostPort}]${path}`;
+        } else {
+            url = `http://${url}`;
+        }
     }
     const newUrl = new URL(url);
     return newUrl.host;
@@ -107,7 +118,7 @@ function allowlist_add_listener(event) {
         url = extractURLHost(url);
     } catch(error) {
         console.warn("Error parsing a domain to add to the allowlist:", {url, error});
-        alert("Please enter a valid domain.");
+        alert("Please enter a valid domain or IP address.");
         return;
     }
     

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -1,5 +1,6 @@
 import { getItemFromLocal, modifyItemInLocal } from "../global/BrowserStorageManager.js";
 import { createElement } from "../global/domUtils.js";
+import { normalizeAllowlistEntry } from "../global/hostUtils.js";
 
 /**
  * A single item in the allowlist display
@@ -75,37 +76,6 @@ async function load_allowlist(allowed_domain_list) {
     allowlist_wrapper.removeAttribute("hidden");
 }
 
-/**
- * Get a well-formed host to match against from an user-supplied URL
- * @param {string} url A URL-like value (eg `https://example.com/file/path/etc`, `discord.com/invite/abcdefg`, `example.com:8080`)
- * @returns {string} Well formatted host portion of url (eg `example.com`, `discord.com`, `example.com:8080`)
- * 
- * @throws Parsing an invalid URL
- */
-function extractURLHost(url) {
-    // Leading/trailing whitespace removal
-    url = url.trim();
-
-    // We don't actually care about the protocol as we only compare url.host
-    // But the URL object will fail to create if no protocol is provided
-    if (!url.match(/^\w*:\/\//)) {
-        const pathStart = url.indexOf("/");
-        const hostPort = pathStart === -1 ? url : url.slice(0, pathStart);
-        const path = pathStart === -1 ? "" : url.slice(pathStart);
-
-        if (hostPort.includes(":") && !hostPort.startsWith("[")) {
-            const isIPv4WithOptionalPort = /^(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?$/.test(hostPort);
-            url = isIPv4WithOptionalPort ?
-                `http://${hostPort}${path}` :
-                `http://[${hostPort}]${path}`;
-        } else {
-            url = `http://${url}`;
-        }
-    }
-    const newUrl = new URL(url);
-    return newUrl.host;
-}
-
 // Allowlist add form bindings
 const allowlist_add_form = document.getElementById("allowlist_add_form");
 function allowlist_add_listener(event) {
@@ -115,10 +85,10 @@ function allowlist_add_listener(event) {
     const form_url = allowlist_add_form.elements["add_domain"];
     let url = form_url.value;
     try {
-        url = extractURLHost(url);
+        url = normalizeAllowlistEntry(url);
     } catch(error) {
-        console.warn("Error parsing a domain to add to the allowlist:", {url, error});
-        alert("Please enter a valid domain or IP address.");
+        console.warn("Error parsing an allowlist entry:", {url, error});
+        alert("Please enter a valid domain, IP address, or CIDR range.");
         return;
     }
     
@@ -132,7 +102,7 @@ function allowlist_add_listener(event) {
             if (!list.includes(url)) {
                 return list.concat(url);
             } else {
-                alert("This domain is already in the list.");
+                alert("This entry is already in the list.");
                 return list;
             }
         }).then(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #66 and #64 by making IP address and CIDR allowlist entries actually take effect.

Also fixes a follow-up issue where whitelisting `127.0.0.1` did not stop `TestPortScans.html` from being blocked.

## Problem

- **#66**: IP allowlist entries were ignored because origin hosts include ports (e.g. `127.0.0.1:8080`) while entries were stored without them.
- **#64**: Homelab users (e.g. Proxmox) need CIDR support for private subnets.
- **TestPortScans regression**: The allowlist only checked the **page origin**, not the **scan target**. Opening `TestPortScans.html` from `file://` or `localhost` scans `127.0.0.1` as a third-party request, so whitelisting `127.0.0.1` had no effect on the destination.

## Solution

- IP entries without a port match the same address on any port
- CIDR ranges match IPv4 and IPv6 origins/destinations
- `localhost` is treated as equivalent to `127.0.0.1`
- **Domain entries** still only match the page origin (e.g. `discord.com`)
- **IP and CIDR entries** match both the page origin and local/private request destinations

## Example

| Page origin | Scan target | Allowlist | Result |
|---|---|---|---|
| `file://` (empty host) | `127.0.0.1:80` | `127.0.0.1` | Allowed |
| `localhost` | `127.0.0.1:80` | `127.0.0.1` | Allowed |
| `evil.com` | `127.0.0.1:80` | `127.0.0.1` | Allowed |
| `evil.com` | `10.0.0.1:80` | `127.0.0.1` | Blocked |
| `evil.com` | `127.0.0.1:80` | `discord.com` | Blocked |
| `discord.com` | `127.0.0.1:80` | `discord.com` | Allowed |

## Test plan

- [x] Verified matching logic for origins, destinations, localhost, CIDR, and domains
- [ ] Add `127.0.0.1` to allowlist, open `TestPortScans.html` from disk, confirm `127.0.0.1` scans are not blocked
- [ ] Add LAN CIDR (e.g. `192.168.1.0/24`) and confirm Proxmox shell/console connections work
- [ ] Confirm `discord.com` allowlist still only applies to pages on discord.com, not all scans to local IPs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4f76-5102-7079-8153-d2f8d159371f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4f76-5102-7079-8153-d2f8d159371f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

