### PR TITLE
Fix multi-GB WebExtensions memory growth on LexisNexis-heavy pages (#52)

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,22 +1,42 @@
-import { getItemFromLocal, setItemInLocal, modifyItemInLocal,
-    addBlockedPortToHost, addBlockedTrackingHost, increaseBadge } from "./global/BrowserStorageManager.js";
+import {
+    getItemFromLocal,
+    setItemInLocal,
+    addBlockedPortToHost,
+    addBlockedTrackingHost,
+    increaseBadge,
+    getAllowedDomainListCached,
+    applyStorageChangesToCaches,
+    resetSessionTabActivity,
+    clearTabActivityData,
+    resetTabDataForNavigation,
+    peekBadgeForTab,
+    flushTabActivity,
+} from "./global/BrowserStorageManager.js";
+import { getTabActivitySnapshot } from "./global/tabActivity.js";
 import { evaluateRequest, createDnsResultCache } from "./global/requestFilter.js";
 
 /** Session-scoped DNS result cache — not persisted to disk. */
 const dnsResultCache = createDnsResultCache();
 
-async function startup(){
-    // No need to check and initialize notification, state, and allow list values as they will 
+async function startup() {
+    // No need to check and initialize notification, state, and allow list values as they will
     // fall back to the default values until explicitly set
     console.log("Startup called");
 
-	// Get the blocking state from cold storage
-    const state = await getItemFromLocal("blocking_enabled", true); 
-	if (state === true) {
-	    start();
-	} else {
-	    stop();
-	}
+    // Drop stale/corrupt per-tab activity left from prior sessions (issue #52).
+    // Popup data is session-scoped in practice; tabs reload and repopulate anyway.
+    await resetSessionTabActivity();
+
+    // Warm the allowlist cache so the first requests avoid a storage round-trip.
+    await getAllowedDomainListCached();
+
+    // Get the blocking state from cold storage
+    const state = await getItemFromLocal("blocking_enabled", true);
+    if (state === true) {
+        start();
+    } else {
+        stop();
+    }
 }
 
 function blockPortScan(requestDetails, url) {
@@ -27,7 +47,7 @@ function blockPortScan(requestDetails, url) {
 
 async function cancel(requestDetails) {
     const decision = await evaluateRequest(requestDetails, {
-        getAllowedDomains: () => getItemFromLocal("allowed_domain_list", []),
+        getAllowedDomains: () => getAllowedDomainListCached(),
         resolveDns: (hostname) => browser.dns.resolve(hostname, ["canonical_name"]),
         dnsCache: dnsResultCache,
     });
@@ -65,7 +85,8 @@ async function cancel(requestDetails) {
     return { cancel: false };
 } // end cancel()
 
-async function start() {  // Enables blocking
+async function start() {
+    // Enables blocking
     try {
         //Add event listener
         browser.webRequest.onBeforeRequest.addListener(
@@ -81,7 +102,8 @@ async function start() {  // Enables blocking
     }
 }
 
-async function stop() {  // Disables blocking
+async function stop() {
+    // Disables blocking
     try {
         //Remove event listener
         browser.webRequest.onBeforeRequest.removeListener(cancel);
@@ -93,7 +115,8 @@ async function stop() {  // Disables blocking
     }
 }
 
-async function isListening() { // returns if blocking is on
+async function isListening() {
+    // returns if blocking is on
     const storage_state = await getItemFromLocal("blocking_enabled", true);
     const listener_attached_state = browser.webRequest.onBeforeRequest.hasListener(cancel);
 
@@ -101,7 +124,7 @@ async function isListening() { // returns if blocking is on
     if (storage_state !== listener_attached_state) {
         console.error("Mismatch in blocking state according to storage value and listener attached status:", {
             storage_state,
-            listener_attached_state
+            listener_attached_state,
         });
     }
 
@@ -110,37 +133,26 @@ async function isListening() { // returns if blocking is on
 }
 
 /**
- * Call by each tab is updated.
- * And if url has changed.
+ * Called when each tab is updated, and if the URL has changed.
  * Borrowed and modified from https://gitlab.com/KevinRoebert/ClearUrls/-/blob/master/core_js/badgedHandler.js
  */
-async function handleUpdated(tabId, changeInfo, tabInfo) {
-    // TODO investigate a better way to interact with current locking practices
-    const badges = await getItemFromLocal("badges", {});
-    if (!badges[tabId] || !changeInfo.url) return;
+function handleUpdated(tabId, changeInfo, tabInfo) {
+    if (!changeInfo.url) return;
 
-    if (badges[tabId].lastURL !== changeInfo.url) {
-        badges[tabId] = {
-            counter: 0,
-            alerted: 0,
-            lastURL: tabInfo.url
-        };
-        await setItemInLocal("badges", badges);
+    const badge = peekBadgeForTab(tabId);
+    if (!badge) return;
 
-        // Clear out the blocked ports for the current tab
-        await modifyItemInLocal("blocked_ports", {},
-            (blocked_ports_object) => {
-                delete blocked_ports_object[tabId];
-                return blocked_ports_object;
-            });
-
-        // Clear out the hosts for the current tab
-        await modifyItemInLocal("blocked_hosts", {},
-            (blocked_hosts_object) => {
-                delete blocked_hosts_object[tabId];
-                return blocked_hosts_object;
-            });
+    if (badge.lastURL !== changeInfo.url) {
+        resetTabDataForNavigation(tabId, tabInfo.url);
     }
+}
+
+/**
+ * Closed tabs must drop their activity maps — otherwise badges/blocked_* grow
+ * without bound across a long browsing session (issue #52 / #47).
+ */
+function handleRemoved(tabId) {
+    clearTabActivityData(tabId);
 }
 
 const extensionOrigin = new URL(browser.runtime.getURL("")).origin;
@@ -151,21 +163,36 @@ async function onMessage(message, sender) {
        https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessageExternal
     */
     if (sender.origin !== extensionOrigin) {
-        console.warn('Message from unexpected origin:', sender.url);
+        console.warn("Message from unexpected origin:", sender.url);
         return;
     }
 
     switch (message.type) {
-        case 'toggleEnabled':
+        case "toggleEnabled":
             message.value ? await start() : await stop();
             break;
+        case "getTabActivity": {
+            // Popup reads live memory (then storage is only a durability backup).
+            await flushTabActivity();
+            const snapshot = getTabActivitySnapshot();
+            const tabId = message.tabId;
+            return {
+                blocked_ports: snapshot.blocked_ports[tabId] ?? snapshot.blocked_ports[String(tabId)] ?? {},
+                blocked_hosts: snapshot.blocked_hosts[tabId] ?? snapshot.blocked_hosts[String(tabId)] ?? [],
+            };
+        }
         default:
-            console.warn('Port Authority: unknown message: ', message);
+            console.warn("Port Authority: unknown message: ", message);
             break;
     }
 }
 browser.runtime.onMessage.addListener(onMessage);
 
+browser.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName !== "local") return;
+    applyStorageChangesToCaches(changes);
+});
+
 startup();
-// Call by each tab is updated.
 browser.tabs.onUpdated.addListener(handleUpdated);
+browser.tabs.onRemoved.addListener(handleRemoved);

--- a/background.js
+++ b/background.js
@@ -33,9 +33,9 @@ async function startup() {
     // Get the blocking state from cold storage
     const state = await getItemFromLocal("blocking_enabled", true);
     if (state === true) {
-        start();
+        await start();
     } else {
-        stop();
+        await stop();
     }
 }
 
@@ -53,15 +53,10 @@ async function cancel(requestDetails) {
     });
 
     if (!decision.cancel) {
-        if (decision.reason === "first-party") {
-            console.debug("Same-origin/first-party request allowed:", {
-                origin: requestDetails.originUrl,
-                request: requestDetails.url,
-            });
-        } else if (decision.reason === "unparseable-origin") {
+        // Avoid per-request console I/O on the hot allow path — logging every
+        // first-party asset on SPAs (Figma, etc.) retains huge console buffers.
+        if (decision.reason === "unparseable-origin") {
             console.error("Aborted filtering on domain due to unparseable originUrl: ", requestDetails.originUrl);
-        } else if (decision.reason === "allowlisted") {
-            console.debug("Aborted filtering on domain due to whitelist: ", requestDetails.originUrl);
         } else if (decision.reason === "unparseable-url") {
             console.error("Error filtering on domain due to unparseable request URL: ", requestDetails.url);
         } else if (decision.reason === "dns-failure") {
@@ -71,12 +66,10 @@ async function cancel(requestDetails) {
     }
 
     if (decision.reason === "portscan") {
-        console.debug("Blocking domain for portscanning: ", decision.url);
         return blockPortScan(requestDetails, decision.url);
     }
 
     if (decision.reason === "threatmetrix") {
-        console.debug("Blocking domain for LexisNexis/ThreatMetrix match:", { url: decision.url });
         increaseBadge(requestDetails, true);
         addBlockedTrackingHost(decision.url, requestDetails.tabId);
         return { cancel: true };
@@ -88,7 +81,12 @@ async function cancel(requestDetails) {
 async function start() {
     // Enables blocking
     try {
-        //Add event listener
+        if (browser.webRequest.onBeforeRequest.hasListener(cancel)) {
+            console.log("Blocking listener already attached");
+            await setItemInLocal("blocking_enabled", true);
+            return;
+        }
+
         browser.webRequest.onBeforeRequest.addListener(
             cancel,
             { urls: ["<all_urls>"] }, // Match all HTTP, HTTPS, FTP, FTPS, WS, WSS URLs.
@@ -105,31 +103,14 @@ async function start() {
 async function stop() {
     // Disables blocking
     try {
-        //Remove event listener
-        browser.webRequest.onBeforeRequest.removeListener(cancel);
-
-        console.log("Removed `onBeforeRequest` listener successfully: blocking disabled");
+        if (browser.webRequest.onBeforeRequest.hasListener(cancel)) {
+            browser.webRequest.onBeforeRequest.removeListener(cancel);
+            console.log("Removed `onBeforeRequest` listener successfully: blocking disabled");
+        }
         await setItemInLocal("blocking_enabled", false);
     } catch (e) {
         console.error("STOP() ", e);
     }
-}
-
-async function isListening() {
-    // returns if blocking is on
-    const storage_state = await getItemFromLocal("blocking_enabled", true);
-    const listener_attached_state = browser.webRequest.onBeforeRequest.hasListener(cancel);
-
-    // If storage says that blocking is enabled when it actually isn't, soft throw an error to the console
-    if (storage_state !== listener_attached_state) {
-        console.error("Mismatch in blocking state according to storage value and listener attached status:", {
-            storage_state,
-            listener_attached_state,
-        });
-    }
-
-    // Rely on the actual listener being attached as the ground source of truth over what storage says
-    return listener_attached_state;
 }
 
 /**

--- a/global/BrowserStorageManager.js
+++ b/global/BrowserStorageManager.js
@@ -19,10 +19,16 @@ const STORAGE_LOCK_KEY = "port_authority_storage_lock";
 /** Coalesce hot-path activity writes so blocked-request storms cannot queue lock work. */
 const TAB_ACTIVITY_PERSIST_MS = 75;
 
+/** Defensive caps so a pathological page cannot grow per-tab maps without bound. */
+const MAX_BLOCKED_HOSTS_PER_TAB = 200;
+const MAX_PORTS_PER_HOST = 100;
+
 /** @type {ReturnType<typeof setTimeout> | null} */
 let tabActivityPersistTimer = null;
 /** @type {Promise<void> | null} */
 let tabActivityPersistInFlight = null;
+/** Bumped to invalidate in-flight persists that started before a session reset. */
+let tabActivityPersistEpoch = 0;
 
 /** @type {string[] | undefined} */
 let allowedDomainListCache;
@@ -298,11 +304,19 @@ export function applyStorageChangesToCaches(changes) {
     }
 }
 
+function clearTabActivityPersistTimer() {
+    if (tabActivityPersistTimer !== null) {
+        clearTimeout(tabActivityPersistTimer);
+        tabActivityPersistTimer = null;
+    }
+}
+
 function scheduleTabActivityPersist() {
     if (tabActivityPersistTimer !== null) return;
     tabActivityPersistTimer = setTimeout(() => {
         tabActivityPersistTimer = null;
-        tabActivityPersistInFlight = persistTabActivityNow().finally(() => {
+        const epoch = tabActivityPersistEpoch;
+        tabActivityPersistInFlight = persistTabActivityNow(epoch).finally(() => {
             tabActivityPersistInFlight = null;
         });
     }, TAB_ACTIVITY_PERSIST_MS);
@@ -313,18 +327,23 @@ function scheduleTabActivityPersist() {
  * @returns {Promise<void>}
  */
 export async function flushTabActivity() {
-    if (tabActivityPersistTimer !== null) {
-        clearTimeout(tabActivityPersistTimer);
-        tabActivityPersistTimer = null;
-    }
+    clearTabActivityPersistTimer();
     if (tabActivityPersistInFlight) {
         await tabActivityPersistInFlight;
     }
-    await persistTabActivityNow();
+    // A mutation during the await may have armed a new debounce timer — drop it
+    // and write the latest snapshot once.
+    clearTabActivityPersistTimer();
+    await persistTabActivityNow(tabActivityPersistEpoch);
 }
 
-async function persistTabActivityNow() {
+async function persistTabActivityNow(epoch = tabActivityPersistEpoch) {
+    // Skip stale writers that began before a session reset.
+    if (epoch !== tabActivityPersistEpoch) return;
+
     const snapshot = getTabActivitySnapshot();
+    if (epoch !== tabActivityPersistEpoch) return;
+
     // One exclusive lock section would be nicer, but existing helpers already
     // serialize via STORAGE_LOCK_KEY — three quick writes beat N per-request writes.
     await setItemInLocal("badges", snapshot.badges);
@@ -346,11 +365,11 @@ export function clearTabActivityData(tabId) {
  * Prevents stale/corrupt per-tab blobs from prior sessions from accumulating (#52).
  */
 export async function resetSessionTabActivity() {
-    if (tabActivityPersistTimer !== null) {
-        clearTimeout(tabActivityPersistTimer);
-        tabActivityPersistTimer = null;
-    }
-    // Wait for any in-flight persist so it cannot rewrite stale data after we clear.
+    clearTabActivityPersistTimer();
+    // Invalidate any in-flight writer so it cannot resurrect stale maps after clear.
+    tabActivityPersistEpoch += 1;
+    const epoch = tabActivityPersistEpoch;
+
     if (tabActivityPersistInFlight) {
         try {
             await tabActivityPersistInFlight;
@@ -358,7 +377,13 @@ export async function resetSessionTabActivity() {
             // ignore — we're about to overwrite anyway
         }
     }
+
+    // Drop timers armed by mutations while we awaited the prior persist.
+    clearTabActivityPersistTimer();
     resetTabActivityMemory();
+
+    if (epoch !== tabActivityPersistEpoch) return;
+
     await setItemInLocal("badges", {});
     await setItemInLocal("blocked_ports", {});
     await setItemInLocal("blocked_hosts", {});
@@ -389,7 +414,7 @@ export function addBlockedPortToHost(url, tabIdString) {
     const host = url.host.split(":")[0]; // TODO replace with more robust method to get host, this might act funky around IPv6 addresses
     const port = "" + (url.port || getPortForProtocol(url.protocol));
 
-    const changed = recordBlockedPort(tabId, host, port);
+    const changed = recordBlockedPort(tabId, host, port, MAX_PORTS_PER_HOST);
     if (changed) scheduleTabActivityPersist();
     return changed;
 }
@@ -405,7 +430,7 @@ export function addBlockedTrackingHost(url, tabIdString) {
     if (Number.isNaN(tabId) || tabId < 0) return false;
 
     const host = url.host;
-    const changed = recordBlockedTrackingHost(tabId, host);
+    const changed = recordBlockedTrackingHost(tabId, host, MAX_BLOCKED_HOSTS_PER_TAB);
     if (changed) scheduleTabActivityPersist();
     return changed;
 }

--- a/global/BrowserStorageManager.js
+++ b/global/BrowserStorageManager.js
@@ -1,9 +1,33 @@
 // TODO remove these eventually, that they're needed is a sign of bad code encapsulation
 import { updateBadges, notifyThreatMetrix, notifyPortScanning } from "./browserActions.js";
 import { getPortForProtocol } from "./constants.js";
+import {
+    clearTabActivity,
+    getBadgeForTab,
+    getTabActivitySnapshot,
+    incrementBadgeCounter,
+    loadTabActivityMemory,
+    recordBlockedPort,
+    recordBlockedTrackingHost,
+    resetTabActivityForNavigation,
+    resetTabActivityMemory,
+} from "./tabActivity.js";
 
 // Key required to access the same lock that's used to control write access to localStorage
 const STORAGE_LOCK_KEY = "port_authority_storage_lock";
+
+/** Coalesce hot-path activity writes so blocked-request storms cannot queue lock work. */
+const TAB_ACTIVITY_PERSIST_MS = 75;
+
+/** @type {ReturnType<typeof setTimeout> | null} */
+let tabActivityPersistTimer = null;
+/** @type {Promise<void> | null} */
+let tabActivityPersistInFlight = null;
+
+/** @type {string[] | undefined} */
+let allowedDomainListCache;
+/** @type {boolean | undefined} */
+let notificationsAllowedCache;
 
 /**
  * @private
@@ -202,102 +226,243 @@ export async function clearItemsInLocal(default_structure = {}) {
 
 
 /**
- * Adds the host and port of the provided url to a list of hosts and ports that were blocked from port scanning.
- * 
- * @param {URL} url URL object built from the url of the tab associated with the tabID
- * @param {string} tabId Id the of the browser tab the port check was executed in
+ * In-memory allowlist used by the blocking hot path.
+ * Avoids a shared storage lock + JSON.parse on every webRequest (issue #52).
+ * @returns {Promise<string[]>}
  */
-export async function addBlockedPortToHost(url, tabIdString) {
-    const tabId = parseInt(tabIdString);
+export async function getAllowedDomainListCached() {
+    if (allowedDomainListCache !== undefined) {
+        return allowedDomainListCache;
+    }
+    allowedDomainListCache = await getItemFromLocal("allowed_domain_list", []);
+    if (!Array.isArray(allowedDomainListCache)) {
+        allowedDomainListCache = [];
+    }
+    return allowedDomainListCache;
+}
+
+/**
+ * Keep the allowlist cache coherent with settings / storage writes.
+ * @param {string[] | undefined} [nextValue] Parsed list, or omit to force reload on next read
+ */
+export function syncAllowedDomainListCache(nextValue) {
+    if (nextValue === undefined) {
+        allowedDomainListCache = undefined;
+        return;
+    }
+    allowedDomainListCache = Array.isArray(nextValue) ? nextValue : [];
+}
+
+/**
+ * @returns {Promise<boolean>}
+ */
+async function getNotificationsAllowedCached() {
+    if (notificationsAllowedCache !== undefined) {
+        return notificationsAllowedCache;
+    }
+    notificationsAllowedCache = await getItemFromLocal("notificationsAllowed", true);
+    return Boolean(notificationsAllowedCache);
+}
+
+/**
+ * @param {boolean | undefined} [nextValue]
+ */
+export function syncNotificationsAllowedCache(nextValue) {
+    if (nextValue === undefined) {
+        notificationsAllowedCache = undefined;
+        return;
+    }
+    notificationsAllowedCache = Boolean(nextValue);
+}
+
+/**
+ * Apply storage.onChanged updates to in-memory settings caches.
+ * @param {{ [key: string]: { newValue?: string } }} changes
+ */
+export function applyStorageChangesToCaches(changes) {
+    if (Object.prototype.hasOwnProperty.call(changes, "allowed_domain_list")) {
+        const raw = changes.allowed_domain_list?.newValue;
+        if (raw === undefined) {
+            syncAllowedDomainListCache(undefined);
+        } else {
+            try {
+                syncAllowedDomainListCache(JSON.parse(raw));
+            } catch {
+                syncAllowedDomainListCache(undefined);
+            }
+        }
+    }
+    if (Object.prototype.hasOwnProperty.call(changes, "notificationsAllowed")) {
+        const raw = changes.notificationsAllowed?.newValue;
+        if (raw === undefined) {
+            syncNotificationsAllowedCache(undefined);
+        } else {
+            try {
+                syncNotificationsAllowedCache(JSON.parse(raw));
+            } catch {
+                syncNotificationsAllowedCache(undefined);
+            }
+        }
+    }
+}
+
+function scheduleTabActivityPersist() {
+    if (tabActivityPersistTimer !== null) return;
+    tabActivityPersistTimer = setTimeout(() => {
+        tabActivityPersistTimer = null;
+        tabActivityPersistInFlight = persistTabActivityNow().finally(() => {
+            tabActivityPersistInFlight = null;
+        });
+    }, TAB_ACTIVITY_PERSIST_MS);
+}
+
+/**
+ * Flush in-memory tab activity to extension storage (single coalesced write path).
+ * @returns {Promise<void>}
+ */
+export async function flushTabActivity() {
+    if (tabActivityPersistTimer !== null) {
+        clearTimeout(tabActivityPersistTimer);
+        tabActivityPersistTimer = null;
+    }
+    if (tabActivityPersistInFlight) {
+        await tabActivityPersistInFlight;
+    }
+    await persistTabActivityNow();
+}
+
+async function persistTabActivityNow() {
+    const snapshot = getTabActivitySnapshot();
+    // One exclusive lock section would be nicer, but existing helpers already
+    // serialize via STORAGE_LOCK_KEY — three quick writes beat N per-request writes.
+    await setItemInLocal("badges", snapshot.badges);
+    await setItemInLocal("blocked_ports", snapshot.blocked_ports);
+    await setItemInLocal("blocked_hosts", snapshot.blocked_hosts);
+}
+
+/**
+ * Clear per-tab activity when a tab closes or navigates.
+ * @param {number|string} tabId
+ */
+export function clearTabActivityData(tabId) {
+    clearTabActivity(tabId);
+    scheduleTabActivityPersist();
+}
+
+/**
+ * Reset session activity in memory and storage.
+ * Prevents stale/corrupt per-tab blobs from prior sessions from accumulating (#52).
+ */
+export async function resetSessionTabActivity() {
+    if (tabActivityPersistTimer !== null) {
+        clearTimeout(tabActivityPersistTimer);
+        tabActivityPersistTimer = null;
+    }
+    resetTabActivityMemory();
+    await setItemInLocal("badges", {});
+    await setItemInLocal("blocked_ports", {});
+    await setItemInLocal("blocked_hosts", {});
+}
+
+/**
+ * Test helper: load storage values into the in-memory activity maps.
+ */
+export async function hydrateTabActivityFromStorage() {
+    const [badges, blocked_ports, blocked_hosts] = await Promise.all([
+        getItemFromLocal("badges", {}),
+        getItemFromLocal("blocked_ports", {}),
+        getItemFromLocal("blocked_hosts", {}),
+    ]);
+    loadTabActivityMemory({ badges, blocked_ports, blocked_hosts });
+}
+
+/**
+ * Adds the host and port of the provided url to a list of hosts and ports that were blocked from port scanning.
+ *
+ * @param {URL} url URL object built from the url of the tab associated with the tabID
+ * @param {string|number} tabIdString Id the of the browser tab the port check was executed in
+ */
+export function addBlockedPortToHost(url, tabIdString) {
+    const tabId = parseInt(tabIdString, 10);
+    if (Number.isNaN(tabId) || tabId < 0) return false;
+
     const host = url.host.split(":")[0]; // TODO replace with more robust method to get host, this might act funky around IPv6 addresses
     const port = "" + (url.port || getPortForProtocol(url.protocol));
 
-    // Grab the blocked ports object from extensions storage
-    return modifyItemInLocal("blocked_ports", {}, (blocked_ports) => {
-        // Grab the array of ports blocked for the host url
-        const tab_hosts = blocked_ports[tabId] || {};
-        let hosts_ports = tab_hosts[host];
-        if (Array.isArray(hosts_ports)) {
-            // Add the port to the array of blocked ports for this host IFF the port doesn't exist
-            if (hosts_ports.indexOf(port) === -1) {
-                hosts_ports = tab_hosts[host].concat([port]);
-                tab_hosts[host] = hosts_ports;
-                blocked_ports[tabId] = tab_hosts;
-            }
-        } else {
-            tab_hosts[host] = [port];
-            blocked_ports[tabId] = tab_hosts;
-        }
-        return blocked_ports;
-    });
+    const changed = recordBlockedPort(tabId, host, port);
+    if (changed) scheduleTabActivityPersist();
+    return changed;
 }
 
 /**
- * Adds the host and port of the provided url to a list of hosts and ports that were blocked from port scanning.
- * 
+ * Adds the host of the provided url to the list of blocked tracking hosts for the tab.
+ *
  * @param {URL} url URL object built from the url of the tab associated with the tabID
- * @param {string} tabId Id the of the browser tab the port check was executed in
+ * @param {string|number} tabIdString Id the of the browser tab the port check was executed in
  */
-export async function addBlockedTrackingHost(url, tabIdString) {
-    const tabId = parseInt(tabIdString);
+export function addBlockedTrackingHost(url, tabIdString) {
+    const tabId = parseInt(tabIdString, 10);
+    if (Number.isNaN(tabId) || tabId < 0) return false;
+
     const host = url.host;
-
-    return modifyItemInLocal("blocked_hosts", {}, (blocked_hosts_tabs) => {
-        let blocked_hosts = blocked_hosts_tabs[tabId] || [];
-
-        if (blocked_hosts.indexOf(host) === -1) {
-            blocked_hosts = blocked_hosts.concat([host]);
-        }
-
-        blocked_hosts_tabs[tabId] = blocked_hosts;
-
-        return blocked_hosts_tabs;
-    });
+    const changed = recordBlockedTrackingHost(tabId, host);
+    if (changed) scheduleTabActivityPersist();
+    return changed;
 }
+
 /**
- * Increases the badged by one.
- * Borrowed and modified from https://gitlab.com/KevinRoebert/ClearUrls/-/blob/master/core_js/badgedHandler.js
+ * Increases the badge by one and optionally fires a one-shot notification.
+ * Memory update is synchronous; disk persistence is coalesced (issue #52).
+ *
+ * @param {{ tabId?: number, url?: string, originUrl?: string } | null} request
+ * @param {boolean} isThreatMetrix
+ * @returns {Promise<void>}
  */
 export async function increaseBadge(request, isThreatMetrix) {
     const tabId = request?.tabId;
     const url = request?.url;
 
     // Error checking for invalid request
-    if (!request || tabId === -1) {
-        console.error('Invalid `request` passed to increaseBadge:', {request, isThreatMetrix});
+    if (!request || tabId === -1 || tabId === undefined || tabId === null) {
+        console.error("Invalid `request` passed to increaseBadge:", { request, isThreatMetrix });
         return;
-    };
+    }
 
-    // Actual badge update
-    return modifyItemInLocal("badges", {}, async (badges) => {
-        // Initialize badge info for the tab if empty
-        if (!badges[tabId]) {
-            badges[tabId] = {
-                counter: 0,
-                alerted: 0,
-                lastURL: url
-            };
+    const { counter, shouldNotify } = incrementBadgeCounter(tabId, url);
+    updateBadges(counter, tabId);
+    scheduleTabActivityPersist();
+
+    if (!shouldNotify) return;
+
+    const notifications_enabled = await getNotificationsAllowedCached();
+    if (!notifications_enabled) return;
+
+    try {
+        const host = new URL(request.originUrl).host;
+        if (isThreatMetrix) {
+            await notifyThreatMetrix(host);
+        } else {
+            await notifyPortScanning(host);
         }
+    } catch (error) {
+        console.error("Failed to notify for blocked request:", { request, error });
+    }
+}
 
-        // Update badge number
-        badges[tabId].counter += 1;
+/**
+ * Reset badge counters and blocked lists after a tab navigates to a new URL.
+ * @param {number|string} tabId
+ * @param {string} lastURL
+ */
+export function resetTabDataForNavigation(tabId, lastURL) {
+    resetTabActivityForNavigation(tabId, lastURL);
+    scheduleTabActivityPersist();
+}
 
-        // TODO better separate concerns between storage related things and browser actions
-        // Update badge text
-        updateBadges(badges[tabId].counter, tabId);
-
-        // TODO better separate concerns between storage related things and browser actions
-        // Update notification alerted status
-        const notifications_enabled = await UNLOCKED_getItemFromLocal("notificationsAllowed", true);
-        if (badges[tabId].alerted === 0 && notifications_enabled) {
-            badges[tabId].alerted += 1;
-            if (isThreatMetrix) {
-                notifyThreatMetrix(new URL(request.originUrl).host);
-            } else {
-                notifyPortScanning(new URL(request.originUrl).host);
-            }
-        }
-
-        return badges;
-    });
+/**
+ * @param {number|string} tabId
+ * @returns {import("./tabActivity.js").BadgeInfo | undefined}
+ */
+export function peekBadgeForTab(tabId) {
+    return getBadgeForTab(tabId);
 }

--- a/global/BrowserStorageManager.js
+++ b/global/BrowserStorageManager.js
@@ -92,9 +92,7 @@ export async function getItemFromLocal(key, default_value) {
     return navigator.locks.request(STORAGE_LOCK_KEY,
         { mode: "shared" }, // allows for simultaneous reads that are guaranteed to not occur in the middle of a `modifyItemInLocal` call
         async (lock) => {
-            const value = await UNLOCKED_getItemFromLocal(key, default_value);
-            console.debug("Reading storage:", {[key]: value});
-            return value;
+            return UNLOCKED_getItemFromLocal(key, default_value);
         }
     );
 }
@@ -116,7 +114,6 @@ export async function setItemInLocal(key, value) {
     // Acquire lock for write access before updating
     return navigator.locks.request(STORAGE_LOCK_KEY, async (lock) => {
         await browser.storage.local.set({ [key]: stringifiedValue });
-        console.debug("Setting storage:", {[key]: value});
         return value;
     });
 }
@@ -164,13 +161,8 @@ export async function modifyItemInLocal(key, default_value, mutate) {
         // Re-stringify and save the changed value
         await browser.storage.local.set({
             [key]: JSON.stringify(new_value)
-        }); 
-
-        console.debug("Updating storage value: ", key, {
-            ["old " + key]: initial_value,
-            ["new " + key]: new_value
         });
-        
+
         // Return result of modification so can use later
         return new_value;
     });
@@ -358,6 +350,14 @@ export async function resetSessionTabActivity() {
         clearTimeout(tabActivityPersistTimer);
         tabActivityPersistTimer = null;
     }
+    // Wait for any in-flight persist so it cannot rewrite stale data after we clear.
+    if (tabActivityPersistInFlight) {
+        try {
+            await tabActivityPersistInFlight;
+        } catch {
+            // ignore — we're about to overwrite anyway
+        }
+    }
     resetTabActivityMemory();
     await setItemInLocal("badges", {});
     await setItemInLocal("blocked_ports", {});
@@ -428,7 +428,11 @@ export async function increaseBadge(request, isThreatMetrix) {
         return;
     }
 
-    const { counter, shouldNotify } = incrementBadgeCounter(tabId, url);
+    const { counter, shouldNotify } = incrementBadgeCounter(
+        tabId,
+        // Prefer the page URL so navigation cleanup compares against tab URLs.
+        request.originUrl || url
+    );
     updateBadges(counter, tabId);
     scheduleTabActivityPersist();
 

--- a/global/requestFilter.js
+++ b/global/requestFilter.js
@@ -182,7 +182,35 @@ async function resolveWithOptionalCache(hostname, deps, skipCache) {
         }
     }
 
-    const resolvePromise = Promise.resolve().then(() => resolveDns(hostname));
+    // Bound hung resolver waits so cancel()/inflight maps cannot pin request
+    // details indefinitely if dns.resolve never settles.
+    const DNS_TIMEOUT_MS = 8000;
+    const resolvePromise = new Promise((resolve, reject) => {
+        let settled = false;
+        const timer = setTimeout(() => {
+            if (settled) return;
+            settled = true;
+            reject(new Error("dns-timeout"));
+        }, DNS_TIMEOUT_MS);
+
+        Promise.resolve()
+            .then(() => resolveDns(hostname))
+            .then(
+                (value) => {
+                    if (settled) return;
+                    settled = true;
+                    clearTimeout(timer);
+                    resolve(value);
+                },
+                (error) => {
+                    if (settled) return;
+                    settled = true;
+                    clearTimeout(timer);
+                    reject(error);
+                }
+            );
+    });
+
     if (useCache) {
         dnsCache.setInflight?.(hostname, resolvePromise);
     }

--- a/global/requestFilter.js
+++ b/global/requestFilter.js
@@ -63,17 +63,26 @@ export const THREATMETRIX_CNAME = {
  * Session-scoped LRU map of hostname → DNS resolve result.
  * Not persisted — avoids a new on-disk privacy surface.
  *
+ * Also tracks in-flight resolves so a request stampede to the same host
+ * (common on SPAs) shares one `browser.dns.resolve` instead of N.
+ *
  * @param {number} [maxSize=256]
  * @returns {{
  *   get: (key: string) => DnsResolveResult | undefined,
  *   set: (key: string, value: DnsResolveResult) => void,
+ *   getInflight: (key: string) => Promise<DnsResolveResult> | undefined,
+ *   setInflight: (key: string, promise: Promise<DnsResolveResult>) => void,
+ *   clearInflight: (key: string) => void,
  *   clear: () => void,
  *   get size(): number,
+ *   get inflightSize(): number,
  * }}
  */
 export function createDnsResultCache(maxSize = 256) {
     /** @type {Map<string, DnsResolveResult>} */
     const map = new Map();
+    /** @type {Map<string, Promise<DnsResolveResult>>} */
+    const inflight = new Map();
 
     return {
         get(key) {
@@ -92,11 +101,24 @@ export function createDnsResultCache(maxSize = 256) {
                 map.delete(oldest);
             }
         },
+        getInflight(key) {
+            return inflight.get(key);
+        },
+        setInflight(key, promise) {
+            inflight.set(key, promise);
+        },
+        clearInflight(key) {
+            inflight.delete(key);
+        },
         clear() {
             map.clear();
+            inflight.clear();
         },
         get size() {
             return map.size;
+        },
+        get inflightSize() {
+            return inflight.size;
         },
     };
 }
@@ -111,7 +133,13 @@ export function createDnsResultCache(maxSize = 256) {
  * @typedef {object} RequestFilterDeps
  * @property {() => Promise<string[]>} getAllowedDomains
  * @property {(hostname: string) => Promise<DnsResolveResult>} resolveDns
- * @property {{ get: (key: string) => DnsResolveResult | undefined, set: (key: string, value: DnsResolveResult) => void }} [dnsCache]
+ * @property {{
+ *   get: (key: string) => DnsResolveResult | undefined,
+ *   set: (key: string, value: DnsResolveResult) => void,
+ *   getInflight?: (key: string) => Promise<DnsResolveResult> | undefined,
+ *   setInflight?: (key: string, promise: Promise<DnsResolveResult>) => void,
+ *   clearInflight?: (key: string) => void,
+ * }} [dnsCache]
  *   Optional in-memory LRU of successful DNS results for this Firefox session.
  */
 
@@ -129,7 +157,8 @@ export function createDnsResultCache(maxSize = 256) {
  */
 
 /**
- * Resolve DNS with optional session cache. Rebinding-like names skip the cache.
+ * Resolve DNS with optional session cache. Rebinding-like names skip the cache
+ * (and in-flight coalescing) so each lookup can observe a rebound answer.
  * @param {string} hostname
  * @param {RequestFilterDeps} deps
  * @param {boolean} skipCache
@@ -138,20 +167,39 @@ export function createDnsResultCache(maxSize = 256) {
 async function resolveWithOptionalCache(hostname, deps, skipCache) {
     const { resolveDns, dnsCache } = deps;
     const useCache = Boolean(dnsCache) && !skipCache;
-    let resolving = useCache ? dnsCache.get(hostname) : undefined;
 
-    if (!resolving) {
-        try {
-            resolving = await resolveDns(hostname);
-        } catch {
-            return { ok: false };
-        }
-        if (useCache) {
-            dnsCache.set(hostname, resolving);
+    if (useCache) {
+        const cached = dnsCache.get(hostname);
+        if (cached) return { ok: true, resolving: cached };
+
+        const pending = dnsCache.getInflight?.(hostname);
+        if (pending) {
+            try {
+                return { ok: true, resolving: await pending };
+            } catch {
+                return { ok: false };
+            }
         }
     }
 
-    return { ok: true, resolving };
+    const resolvePromise = Promise.resolve().then(() => resolveDns(hostname));
+    if (useCache) {
+        dnsCache.setInflight?.(hostname, resolvePromise);
+    }
+
+    try {
+        const resolving = await resolvePromise;
+        if (useCache) {
+            dnsCache.set(hostname, resolving);
+        }
+        return { ok: true, resolving };
+    } catch {
+        return { ok: false };
+    } finally {
+        if (useCache) {
+            dnsCache.clearInflight?.(hostname);
+        }
+    }
 }
 
 /**

--- a/global/tabActivity.js
+++ b/global/tabActivity.js
@@ -1,0 +1,165 @@
+/**
+ * Session-scoped in-memory store for per-tab blocking activity.
+ *
+ * Issue #52: writing `badges` / `blocked_ports` / `blocked_hosts` through the
+ * exclusive storage lock on every blocked request queued thousands of
+ * JSON.stringify copies and lock waiters, ballooning WebExtensions RAM into
+ * multi-GB territory on LexisNexis-heavy pages (and busy SPAs like Figma).
+ *
+ * Live state lives here; callers coalesce persistence separately.
+ */
+
+/** @typedef {{ counter: number, alerted: number, lastURL: string }} BadgeInfo */
+
+/** @type {{ [tabId: string]: BadgeInfo }} */
+let badges = {};
+
+/** @type {{ [tabId: string]: { [host: string]: string[] } }} */
+let blockedPorts = {};
+
+/** @type {{ [tabId: string]: string[] }} */
+let blockedHosts = {};
+
+/**
+ * Snapshot of in-memory activity (deep-enough copies for safe persistence).
+ */
+export function getTabActivitySnapshot() {
+    return {
+        badges: clone(badges),
+        blocked_ports: clone(blockedPorts),
+        blocked_hosts: clone(blockedHosts),
+    };
+}
+
+export function getBadgeForTab(tabId) {
+    return badges[tabId] ?? badges[String(tabId)];
+}
+
+/**
+ * Replace in-memory badge entry for a tab (used when the tab navigates).
+ * @param {number|string} tabId
+ * @param {BadgeInfo} info
+ */
+export function setBadgeForTab(tabId, info) {
+    badges[tabId] = info;
+}
+
+/**
+ * Drop all activity for a tab (tab closed).
+ * @param {number|string} tabId
+ */
+export function clearTabActivity(tabId) {
+    // Plain-object keys are always strings, so numeric and string ids alias.
+    delete badges[tabId];
+    delete blockedPorts[tabId];
+    delete blockedHosts[tabId];
+}
+
+/**
+ * Clear blocked host/port lists for a tab and reset its badge after navigation.
+ * @param {number|string} tabId
+ * @param {string} lastURL
+ */
+export function resetTabActivityForNavigation(tabId, lastURL) {
+    delete blockedPorts[tabId];
+    delete blockedHosts[tabId];
+    badges[tabId] = {
+        counter: 0,
+        alerted: 0,
+        lastURL,
+    };
+}
+
+/**
+ * Record a blocked port-scan target.
+ * @param {number} tabId
+ * @param {string} host
+ * @param {string} port
+ * @returns {boolean} true when a new port was recorded
+ */
+export function recordBlockedPort(tabId, host, port) {
+    const tabHosts = blockedPorts[tabId] || (blockedPorts[tabId] = {});
+    const ports = tabHosts[host];
+    if (Array.isArray(ports)) {
+        if (ports.includes(port)) return false;
+        tabHosts[host] = ports.concat([port]);
+    } else {
+        tabHosts[host] = [port];
+    }
+    return true;
+}
+
+/**
+ * Record a blocked ThreatMetrix/tracking host.
+ * @param {number} tabId
+ * @param {string} host
+ * @returns {boolean} true when a new host was recorded
+ */
+export function recordBlockedTrackingHost(tabId, host) {
+    const list = blockedHosts[tabId] || (blockedHosts[tabId] = []);
+    if (list.includes(host)) return false;
+    blockedHosts[tabId] = list.concat([host]);
+    return true;
+}
+
+/**
+ * Increment the per-tab block counter.
+ * @param {number} tabId
+ * @param {string} url
+ * @returns {{ counter: number, alerted: number, lastURL: string, shouldNotify: boolean }}
+ */
+export function incrementBadgeCounter(tabId, url) {
+    if (!badges[tabId]) {
+        badges[tabId] = {
+            counter: 0,
+            alerted: 0,
+            lastURL: url,
+        };
+    }
+
+    badges[tabId].counter += 1;
+    const shouldNotify = badges[tabId].alerted === 0;
+    if (shouldNotify) {
+        badges[tabId].alerted += 1;
+    }
+
+    return {
+        counter: badges[tabId].counter,
+        alerted: badges[tabId].alerted,
+        lastURL: badges[tabId].lastURL,
+        shouldNotify,
+    };
+}
+
+/**
+ * Wipe in-memory maps (startup reset / tests).
+ */
+export function resetTabActivityMemory() {
+    badges = {};
+    blockedPorts = {};
+    blockedHosts = {};
+}
+
+/**
+ * Hydrate memory from already-parsed storage values (tests / rare recovery).
+ * @param {{ badges?: object, blocked_ports?: object, blocked_hosts?: object }} data
+ */
+export function loadTabActivityMemory(data = {}) {
+    badges = data.badges && typeof data.badges === "object" ? data.badges : {};
+    blockedPorts =
+        data.blocked_ports && typeof data.blocked_ports === "object"
+            ? data.blocked_ports
+            : {};
+    blockedHosts =
+        data.blocked_hosts && typeof data.blocked_hosts === "object"
+            ? data.blocked_hosts
+            : {};
+}
+
+function clone(value) {
+    try {
+        return structuredClone(value);
+    } catch {
+        return JSON.parse(JSON.stringify(value));
+    }
+}

--- a/global/tabActivity.js
+++ b/global/tabActivity.js
@@ -36,15 +36,6 @@ export function getBadgeForTab(tabId) {
 }
 
 /**
- * Replace in-memory badge entry for a tab (used when the tab navigates).
- * @param {number|string} tabId
- * @param {BadgeInfo} info
- */
-export function setBadgeForTab(tabId, info) {
-    badges[tabId] = info;
-}
-
-/**
  * Drop all activity for a tab (tab closed).
  * @param {number|string} tabId
  */

--- a/global/tabActivity.js
+++ b/global/tabActivity.js
@@ -68,11 +68,12 @@ export function resetTabActivityForNavigation(tabId, lastURL) {
  * @param {string} port
  * @returns {boolean} true when a new port was recorded
  */
-export function recordBlockedPort(tabId, host, port) {
+export function recordBlockedPort(tabId, host, port, maxPortsPerHost = 100) {
     const tabHosts = blockedPorts[tabId] || (blockedPorts[tabId] = {});
     const ports = tabHosts[host];
     if (Array.isArray(ports)) {
         if (ports.includes(port)) return false;
+        if (ports.length >= maxPortsPerHost) return false;
         tabHosts[host] = ports.concat([port]);
     } else {
         tabHosts[host] = [port];
@@ -86,9 +87,10 @@ export function recordBlockedPort(tabId, host, port) {
  * @param {string} host
  * @returns {boolean} true when a new host was recorded
  */
-export function recordBlockedTrackingHost(tabId, host) {
+export function recordBlockedTrackingHost(tabId, host, maxHostsPerTab = 200) {
     const list = blockedHosts[tabId] || (blockedHosts[tabId] = []);
     if (list.includes(host)) return false;
+    if (list.length >= maxHostsPerTab) return false;
     blockedHosts[tabId] = list.concat([host]);
     return true;
 }

--- a/popup/PopupUI.js
+++ b/popup/PopupUI.js
@@ -3,15 +3,27 @@ import { getActiveTabId } from "../global/browserActions.js";
 import { createElement } from "../global/domUtils.js";
 
 /**
- * Data fetching only, separated from rendering logic
- * @param {"blocked_ports" | "blocked_hosts"} data_type Which storage key to extract the blocking activity data from
+ * Prefer live background memory (issue #52 coalesced writes) with storage fallback.
+ * @param {"blocked_ports" | "blocked_hosts"} data_type
  */
 async function fetch_tabs_blocking_data(data_type) {
-    // TODO rework this when flipping data structure as discussed in issue #47: https://github.com/ACK-J/Port_Authority/issues/47
+    const tab_id = await getActiveTabId();
+
+    try {
+        const live = await browser.runtime.sendMessage({
+            type: "getTabActivity",
+            tabId: tab_id,
+        });
+        if (live && Object.prototype.hasOwnProperty.call(live, data_type)) {
+            return live[data_type];
+        }
+    } catch (error) {
+        console.warn("Falling back to storage for popup data:", error);
+    }
+
+    // TODO rework this when flipping data structure as discussed in issue #47
     const all_tabs_data = await getItemFromLocal(data_type, {});
     if (Object.keys(all_tabs_data).length === 0) return;
-
-    const tab_id = await getActiveTabId();
     return all_tabs_data[tab_id];
 }
 

--- a/tests/BrowserStorageManager.test.js
+++ b/tests/BrowserStorageManager.test.js
@@ -134,12 +134,14 @@ async function runQuiet() {
 
     suite("addBlockedPortToHost");
     {
-        await storageApi.clearItemsInLocal({});
-        await storageApi.addBlockedPortToHost(new URL("http://127.0.0.1:22/"), "7");
-        await storageApi.addBlockedPortToHost(new URL("http://127.0.0.1:80/"), "7");
-        await storageApi.addBlockedPortToHost(new URL("http://127.0.0.1:22/"), "7");
-        await storageApi.addBlockedPortToHost(new URL("http://10.0.0.1:445/"), "7");
-        await storageApi.addBlockedPortToHost(new URL("https://192.168.0.1/"), "8");
+        await storageApi.resetSessionTabActivity();
+
+        storageApi.addBlockedPortToHost(new URL("http://127.0.0.1:22/"), "7");
+        storageApi.addBlockedPortToHost(new URL("http://127.0.0.1:80/"), "7");
+        storageApi.addBlockedPortToHost(new URL("http://127.0.0.1:22/"), "7");
+        storageApi.addBlockedPortToHost(new URL("http://10.0.0.1:445/"), "7");
+        storageApi.addBlockedPortToHost(new URL("https://192.168.0.1/"), "8");
+        await storageApi.flushTabActivity();
 
         const ports = await storageApi.getItemFromLocal("blocked_ports", {});
         assertEqual(ports[7]["127.0.0.1"], ["22", "80"], "ports collected without dupes");
@@ -147,18 +149,20 @@ async function runQuiet() {
         assertEqual(ports[8]["192.168.0.1"], ["443"], "default https port recorded");
     }
     {
-        await storageApi.addBlockedPortToHost(new URL("http://172.16.0.1/"), "9");
+        storageApi.addBlockedPortToHost(new URL("http://172.16.0.1/"), "9");
+        await storageApi.flushTabActivity();
         const ports = await storageApi.getItemFromLocal("blocked_ports", {});
         assertEqual(ports[9]["172.16.0.1"], ["80"], "default http port");
     }
 
     suite("addBlockedTrackingHost");
     {
-        await storageApi.clearItemsInLocal({});
-        await storageApi.addBlockedTrackingHost(new URL("https://cdn.brand.com/tmx.js"), "3");
-        await storageApi.addBlockedTrackingHost(new URL("https://cdn.brand.com/tmx.js"), "3");
-        await storageApi.addBlockedTrackingHost(new URL("https://other.brand.com/x"), "3");
-        await storageApi.addBlockedTrackingHost(new URL("https://cdn.brand.com/tmx.js"), "4");
+        await storageApi.resetSessionTabActivity();
+        storageApi.addBlockedTrackingHost(new URL("https://cdn.brand.com/tmx.js"), "3");
+        storageApi.addBlockedTrackingHost(new URL("https://cdn.brand.com/tmx.js"), "3");
+        storageApi.addBlockedTrackingHost(new URL("https://other.brand.com/x"), "3");
+        storageApi.addBlockedTrackingHost(new URL("https://cdn.brand.com/tmx.js"), "4");
+        await storageApi.flushTabActivity();
 
         const hosts = await storageApi.getItemFromLocal("blocked_hosts", {});
         assertEqual(hosts[3], ["cdn.brand.com", "other.brand.com"], "unique hosts per tab");
@@ -168,6 +172,8 @@ async function runQuiet() {
     suite("increaseBadge");
     {
         await storageApi.clearItemsInLocal({ notificationsAllowed: true });
+        await storageApi.resetSessionTabActivity();
+        storageApi.syncNotificationsAllowedCache(true);
         badges.length = 0;
         notifications.length = 0;
 
@@ -179,6 +185,7 @@ async function runQuiet() {
             { tabId: 11, url: "http://127.0.0.1:80/", originUrl: "https://scanner.example/" },
             false
         );
+        await storageApi.flushTabActivity();
 
         const badgeState = await storageApi.getItemFromLocal("badges", {});
         assertEqual(badgeState[11].counter, 2, "badge counter increments");
@@ -188,6 +195,8 @@ async function runQuiet() {
     }
     {
         await storageApi.clearItemsInLocal({ notificationsAllowed: true });
+        await storageApi.resetSessionTabActivity();
+        storageApi.syncNotificationsAllowedCache(true);
         notifications.length = 0;
         await storageApi.increaseBadge(
             { tabId: 12, url: "https://tmx.example/", originUrl: "https://shop.example/" },
@@ -197,6 +206,8 @@ async function runQuiet() {
     }
     {
         await storageApi.clearItemsInLocal({ notificationsAllowed: false });
+        await storageApi.resetSessionTabActivity();
+        storageApi.syncNotificationsAllowedCache(false);
         notifications.length = 0;
         await storageApi.increaseBadge(
             { tabId: 13, url: "http://127.0.0.1/", originUrl: "https://x.example/" },
@@ -208,6 +219,80 @@ async function runQuiet() {
         await storageApi.increaseBadge(null, false);
         await storageApi.increaseBadge({ tabId: -1, url: "http://x/" }, false);
         assert(true, "invalid increaseBadge calls do not throw");
+    }
+
+    suite("tab activity coalescing and cleanup (issue #52)");
+    {
+        await storageApi.resetSessionTabActivity();
+
+        let setCalls = 0;
+        const innerSet = storage.set.bind(storage);
+        storage.set = async (obj) => {
+            setCalls += 1;
+            return innerSet(obj);
+        };
+
+        const setsBeforeBurst = setCalls;
+        for (let i = 0; i < 500; i++) {
+            storageApi.addBlockedTrackingHost(
+                new URL(`https://h-${i % 5}.online-metrix.net/x`),
+                "42"
+            );
+        }
+        assertEqual(setCalls, setsBeforeBurst, "no storage writes during sync blocked-host burst");
+
+        await storageApi.flushTabActivity();
+        assert(setCalls > setsBeforeBurst, "flush persists coalesced activity");
+
+        const hosts = await storageApi.getItemFromLocal("blocked_hosts", {});
+        assertEqual(hosts[42].length, 5, "unique hosts retained after burst");
+
+        storageApi.syncNotificationsAllowedCache(false);
+        const setsBeforeBadges = setCalls;
+        for (let i = 0; i < 100; i++) {
+            await storageApi.increaseBadge(
+                {
+                    tabId: 42,
+                    url: `https://h-${i % 5}.online-metrix.net/x`,
+                    originUrl: "https://bank.example/",
+                },
+                true
+            );
+        }
+        await storageApi.flushTabActivity();
+        const badgeState = await storageApi.getItemFromLocal("badges", {});
+        assertEqual(badgeState[42].counter, 100, "all increments applied in memory");
+        assert(
+            setCalls - setsBeforeBadges <= 10,
+            "badge storm does not create one storage write per increment"
+        );
+
+        storageApi.clearTabActivityData(42);
+        await storageApi.flushTabActivity();
+        const clearedHosts = await storageApi.getItemFromLocal("blocked_hosts", {});
+        const clearedBadges = await storageApi.getItemFromLocal("badges", {});
+        assertEqual(clearedHosts[42], undefined, "tab close clears blocked hosts");
+        assertEqual(clearedBadges[42], undefined, "tab close clears badges");
+
+        storage.set = innerSet;
+    }
+
+    suite("allowlist cache");
+    {
+        await storageApi.setItemInLocal("allowed_domain_list", ["a.example"]);
+        storageApi.syncAllowedDomainListCache(undefined);
+        const first = await storageApi.getAllowedDomainListCached();
+        assertEqual(first, ["a.example"], "cache loads from storage");
+
+        await storage.set({ allowed_domain_list: JSON.stringify(["stale-ignored.example"]) });
+        const second = await storageApi.getAllowedDomainListCached();
+        assertEqual(second, ["a.example"], "hot path keeps cached allowlist");
+
+        storageApi.applyStorageChangesToCaches({
+            allowed_domain_list: { newValue: JSON.stringify(["fresh.example"]) },
+        });
+        const third = await storageApi.getAllowedDomainListCached();
+        assertEqual(third, ["fresh.example"], "storage.onChanged refreshes cache");
     }
 
     assert(typeof storageApi.getItemFromLocal === "function", "API exported");

--- a/tests/manifest.test.js
+++ b/tests/manifest.test.js
@@ -46,7 +46,7 @@ export async function run() {
     assert(background.includes("dnsCache"), "passes dnsCache to evaluateRequest");
     assert(background.includes("toggleEnabled"), "handles toggle messages");
     assert(background.includes("onBeforeRequest"), "registers webRequest listener");
-    assert(background.includes("allowed_domain_list") || background.includes("getAllowedDomainListCached"), "reads allowlist from storage/cache");
+    assert(background.includes("hasListener"), "guards against duplicate blocking listeners");
     assert(background.includes("onRemoved"), "cleans up tab activity on tab close");
     assert(background.includes("resetSessionTabActivity"), "resets stale session activity on startup");
     assert(background.includes("getAllowedDomainListCached"), "uses cached allowlist on hot path");
@@ -56,6 +56,7 @@ export async function run() {
     assert(requestFilter.includes("THREATMETRIX_SUFFIXES"), "exports auditable suffix list");
     assert(requestFilter.includes("matchesThreatMetrixHost"), "exports host matcher");
     assert(requestFilter.includes("createDnsResultCache"), "exports DNS LRU helper");
+    assert(requestFilter.includes("getInflight"), "DNS cache coalesces in-flight resolves");
     assert(requestFilter.includes("threatmetrix.com"), "lists threatmetrix.com");
     assert(requestFilter.includes("lexisnexisrisk.com"), "lists lexisnexisrisk.com");
     assert(requestFilter.includes("lnrsoftware.com"), "lists lnrsoftware.com");

--- a/tests/manifest.test.js
+++ b/tests/manifest.test.js
@@ -46,7 +46,10 @@ export async function run() {
     assert(background.includes("dnsCache"), "passes dnsCache to evaluateRequest");
     assert(background.includes("toggleEnabled"), "handles toggle messages");
     assert(background.includes("onBeforeRequest"), "registers webRequest listener");
-    assert(background.includes("allowed_domain_list"), "reads allowlist from storage");
+    assert(background.includes("allowed_domain_list") || background.includes("getAllowedDomainListCached"), "reads allowlist from storage/cache");
+    assert(background.includes("onRemoved"), "cleans up tab activity on tab close");
+    assert(background.includes("resetSessionTabActivity"), "resets stale session activity on startup");
+    assert(background.includes("getAllowedDomainListCached"), "uses cached allowlist on hot path");
 
     suite("requestFilter.js ThreatMetrix remediation surface");
     const requestFilter = readText("global/requestFilter.js");
@@ -69,6 +72,7 @@ export async function run() {
         "global/requestFilter.js",
         "global/allowlist.js",
         "global/BrowserStorageManager.js",
+        "global/tabActivity.js",
         "global/browserActions.js",
         "global/constants.js",
         "global/domUtils.js",

--- a/tests/requestFilter.test.js
+++ b/tests/requestFilter.test.js
@@ -584,6 +584,31 @@ export async function run() {
         assertEqual(cache.inflightSize, 0, "in-flight cleared after settle");
         assertEqual(resolveCount, 1, "still a single resolve after stampede");
     }
+    {
+        // Failed resolves must clear in-flight so later requests can retry
+        const cache = createDnsResultCache();
+        let resolveCount = 0;
+        const resolveDns = async () => {
+            resolveCount += 1;
+            if (resolveCount === 1) throw new Error("TEMP_FAILURE");
+            return { addresses: ["203.0.113.1"], canonicalName: "cdn.retry.example" };
+        };
+
+        const first = await evaluateRequest(
+            req({ url: "https://cdn.retry.example/a.js" }),
+            deps({ resolveDns, dnsCache: cache })
+        );
+        assertEqual(first.reason, "dns-failure", "first attempt fails open");
+        assertEqual(cache.inflightSize, 0, "inflight cleared after failure");
+        assertEqual(cache.size, 0, "failures are not cached");
+
+        const second = await evaluateRequest(
+            req({ url: "https://cdn.retry.example/b.js" }),
+            deps({ resolveDns, dnsCache: cache })
+        );
+        assertEqual(second.cancel, false, "retry after failure succeeds");
+        assertEqual(resolveCount, 2, "second request re-resolves after failure");
+    }
 
     suite("DNS failure fails open");
     {

--- a/tests/requestFilter.test.js
+++ b/tests/requestFilter.test.js
@@ -552,6 +552,38 @@ export async function run() {
         assertEqual(second.reason, "threatmetrix", "cached CNAME block");
         assertEqual(resolveCount, 1, "CNAME path cached after first resolve");
     }
+    {
+        // Parallel stampede to the same host must share one in-flight resolve
+        const cache = createDnsResultCache();
+        let resolveCount = 0;
+        let release;
+        const gate = new Promise((resolve) => {
+            release = resolve;
+        });
+        const resolveDns = async (hostname) => {
+            resolveCount += 1;
+            await gate;
+            return { addresses: ["203.0.113.1"], canonicalName: hostname };
+        };
+
+        const requests = Promise.all([
+            evaluateRequest(req({ url: "https://cdn.stampede.example/a.js" }), deps({ resolveDns, dnsCache: cache })),
+            evaluateRequest(req({ url: "https://cdn.stampede.example/b.js" }), deps({ resolveDns, dnsCache: cache })),
+            evaluateRequest(req({ url: "https://cdn.stampede.example/c.js" }), deps({ resolveDns, dnsCache: cache })),
+            evaluateRequest(req({ url: "https://cdn.stampede.example/d.js" }), deps({ resolveDns, dnsCache: cache })),
+        ]);
+
+        // Let all four hit the in-flight wait before DNS completes.
+        await new Promise((r) => setTimeout(r, 0));
+        assertEqual(resolveCount, 1, "only one DNS resolve started for parallel stampede");
+        assertEqual(cache.inflightSize, 1, "one in-flight promise tracked");
+        release();
+        const results = await requests;
+        assert(results.every((r) => r.cancel === false), "all stampede requests complete");
+        assertEqual(cache.size, 1, "result cached once");
+        assertEqual(cache.inflightSize, 0, "in-flight cleared after settle");
+        assertEqual(resolveCount, 1, "still a single resolve after stampede");
+    }
 
     suite("DNS failure fails open");
     {

--- a/tests/run.js
+++ b/tests/run.js
@@ -15,6 +15,7 @@ const suites = [
     "./allowlist.test.js",
     "./domUtils.test.js",
     "./browserActions.test.js",
+    "./tabActivity.test.js",
     "./BrowserStorageManager.test.js",
     "./manifest.test.js",
 ];

--- a/tests/tabActivity.test.js
+++ b/tests/tabActivity.test.js
@@ -52,6 +52,20 @@ export async function run() {
         assertEqual(snap.badges[3], undefined, "badges cleared");
     }
 
+    suite("tabActivity caps prevent unbounded growth");
+    {
+        resetTabActivityMemory();
+        for (let i = 0; i < 250; i++) {
+            recordBlockedTrackingHost(1, `h${i}.example`, 200);
+        }
+        assertEqual(getTabActivitySnapshot().blocked_hosts[1].length, 200, "host list capped");
+
+        for (let p = 0; p < 150; p++) {
+            recordBlockedPort(1, "10.0.0.1", String(p), 100);
+        }
+        assertEqual(getTabActivitySnapshot().blocked_ports[1]["10.0.0.1"].length, 100, "ports per host capped");
+    }
+
     suite("tabActivity navigation reset");
     {
         resetTabActivityMemory();

--- a/tests/tabActivity.test.js
+++ b/tests/tabActivity.test.js
@@ -1,0 +1,69 @@
+import {
+    suite,
+    assert,
+    assertEqual,
+} from "./harness.js";
+import {
+    clearTabActivity,
+    getTabActivitySnapshot,
+    incrementBadgeCounter,
+    recordBlockedPort,
+    recordBlockedTrackingHost,
+    resetTabActivityForNavigation,
+    resetTabActivityMemory,
+} from "../global/tabActivity.js";
+
+export async function run() {
+    suite("tabActivity in-memory maps");
+    {
+        resetTabActivityMemory();
+        assertEqual(recordBlockedPort(1, "127.0.0.1", "22"), true, "first port recorded");
+        assertEqual(recordBlockedPort(1, "127.0.0.1", "22"), false, "duplicate port ignored");
+        assertEqual(recordBlockedPort(1, "127.0.0.1", "80"), true, "second port recorded");
+        assertEqual(recordBlockedTrackingHost(1, "tmx.example"), true, "tracking host recorded");
+        assertEqual(recordBlockedTrackingHost(1, "tmx.example"), false, "duplicate tracking host ignored");
+
+        const snap = getTabActivitySnapshot();
+        assertEqual(snap.blocked_ports[1]["127.0.0.1"], ["22", "80"], "ports snapshot");
+        assertEqual(snap.blocked_hosts[1], ["tmx.example"], "hosts snapshot");
+    }
+
+    suite("tabActivity badge increments");
+    {
+        resetTabActivityMemory();
+        const first = incrementBadgeCounter(9, "https://a.example/");
+        assertEqual(first.counter, 1, "first increment");
+        assertEqual(first.shouldNotify, true, "first block notifies");
+        const second = incrementBadgeCounter(9, "https://a.example/");
+        assertEqual(second.counter, 2, "second increment");
+        assertEqual(second.shouldNotify, false, "subsequent blocks do not re-notify");
+    }
+
+    suite("tabActivity cleanup");
+    {
+        resetTabActivityMemory();
+        recordBlockedPort(3, "10.0.0.1", "445");
+        recordBlockedTrackingHost(3, "fp.example");
+        incrementBadgeCounter(3, "https://x/");
+        clearTabActivity(3);
+        const snap = getTabActivitySnapshot();
+        assertEqual(snap.blocked_ports[3], undefined, "ports cleared");
+        assertEqual(snap.blocked_hosts[3], undefined, "hosts cleared");
+        assertEqual(snap.badges[3], undefined, "badges cleared");
+    }
+
+    suite("tabActivity navigation reset");
+    {
+        resetTabActivityMemory();
+        recordBlockedPort(5, "10.0.0.2", "22");
+        recordBlockedTrackingHost(5, "ln.example");
+        incrementBadgeCounter(5, "https://old.example/");
+        resetTabActivityForNavigation(5, "https://new.example/");
+        const snap = getTabActivitySnapshot();
+        assertEqual(snap.blocked_ports[5], undefined, "ports cleared on navigate");
+        assertEqual(snap.blocked_hosts[5], undefined, "hosts cleared on navigate");
+        assertEqual(snap.badges[5].counter, 0, "badge counter reset");
+        assertEqual(snap.badges[5].lastURL, "https://new.example/", "lastURL updated");
+        assert(true, "navigation reset keeps a badge slot");
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses [#52](https://github.com/ACK-J/Port_Authority/issues/52): WebExtensions RAM ballooning into multiple GB on sites that trigger LexisNexis/ThreatMetrix blocking (also reported with Figma).

### Root causes

1. **Storage-lock storm on the block path** — every blocked request fired `increaseBadge` + `addBlockedTrackingHost`/`addBlockedPortToHost` as fire-and-forget work that each acquired the exclusive Web Lock and `JSON.stringify`'d the entire `badges` / `blocked_*` objects. Busy pages queued thousands of pending copies.
2. **Per-request allowlist I/O** — every `webRequest` awaited `getItemFromLocal("allowed_domain_list")` (shared lock + parse).
3. **No tab-close cleanup** — per-tab maps grew for the life of the browser session (`tabs.onRemoved` was never registered; related discussion in #47).
4. **Stale session leftovers** — corrupt/bloated per-tab blobs could survive across restarts (matches the “reinstall fixed it” reports).

### Fixes

- New in-memory `tabActivity` store; disk writes are debounced/coalesced
- Cached allowlist (+ `notificationsAllowed`) invalidated via `storage.onChanged`
- `tabs.onRemoved` clears per-tab activity
- Startup resets `badges` / `blocked_ports` / `blocked_hosts` so prior-session junk cannot accumulate
- Popup reads live background memory (with storage fallback)

### Tests

`npm test` — 446 passed, including coalescing, tab cleanup, and allowlist cache coverage.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3d34b3a-9ae1-4f4a-8d6f-abbe3debd844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3d34b3a-9ae1-4f4a-8d6f-abbe3debd844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

