### PR TITLE
Add IP address and CIDR support to the allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,14 @@ This addon blocks websites from using javascript to port scan your computer/inte
 1. Blocks all possible types of port scanning through your browser (HTTP/HTTPS/WS/WSS/FTP/FTPS)
 2. Dynamically blocks the ThreatMetrix tracking scripts made by one of the largest and least ethical data brokers in the world (Lexis Nexis)
 3. Easily auditable, with the core functionality being about 250 lines of code. [HERE](https://github.com/ACK-J/Port_Authority/blob/main/background.js)
-4. Provides an optional whitelist to prevent portscans and tracking scripts from being blocked on trusted domains
+4. Provides an optional allowlist to prevent portscans and tracking scripts from being blocked on trusted domains, IP addresses, and CIDR ranges
 5. Gives a nice notification when one of the above scenarios are blocked
 6. This addon doesn't store or log browsing history. Blocking decisions stay in memory for the current browser session (badge counters / blocked host lists per tab). To decide whether a third-party host is a LexisNexis/ThreatMetrix endpoint, the addon may issue a DNS CNAME lookup via Firefox's `dns` API for hosts that are not already on the known ThreatMetrix suffix list; results are cached in memory for the session only and are never written to disk or sent to any Port Authority server.
+
+## Allowlist
+- **Domains** (e.g. `discord.com`) match the page origin only — including an optional non-default port when present
+- **IP addresses** (e.g. `127.0.0.1`) without a port match that address on any port for both the page origin and local request destinations
+- **CIDR ranges** (e.g. `192.168.1.0/24`) match any IPv4/IPv6 address in the range, which is useful for homelab UIs such as Proxmox
 
 ## Donations
 - Monero Address: `89jYJvX3CaFNv1T6mhg69wK5dMQJSF3aG2AYRNU1ZSo6WbccGtJN7TNMAf39vrmKNR6zXUKxJVABggR4a8cZDGST11Q4yS8`
@@ -34,10 +39,11 @@ This addon blocks websites from using javascript to port scan your computer/inte
 - Other third-party hosts may still be CNAME-checked once per hostname per session via an in-memory LRU; rebinding-like names skip the cache so a later private answer is not masked
 - Hostname compares strip trailing dots so FQDN forms like `h.online-metrix.net.` still match
 - Transient DNS failures fail open (request allowed) after an explicit catch; known ThreatMetrix suffixes do not depend on DNS and are still blocked
+- Allowlist matching lives in `global/allowlist.js`: domains use exact `URL.host` equality; portless IP entries and CIDR ranges use shared IP helpers from `global/privateAddress.js`
 
 ## Automated Tests
 
-Unit tests cover private-address classification, request-filter decisions (port scans, DNS rebinding, ThreatMetrix CNAMEs, allowlist), storage helpers, notifications/badges, allowlist parsing, DOM helpers, and manifest wiring.
+Unit tests cover private-address classification, request-filter decisions (port scans, DNS rebinding, ThreatMetrix CNAMEs, allowlist including IP/CIDR), storage helpers, notifications/badges, allowlist parsing, DOM helpers, and manifest wiring.
 
 ```bash
 npm test

--- a/global/allowlist.js
+++ b/global/allowlist.js
@@ -1,6 +1,12 @@
 /**
- * Helpers for the domain allowlist used by settings UI and request filtering.
+ * Helpers for the domain/IP/CIDR allowlist used by settings UI and request filtering.
  */
+import {
+    isLiteralIpHostname,
+    normalizeHostname,
+    parseIPv4Octets,
+    expandIPv6,
+} from "./privateAddress.js";
 
 /**
  * Get a well-formed host to match against from a user-supplied URL-like string.
@@ -11,19 +17,234 @@
 export function extractURLHost(url) {
     url = url.trim();
 
-    // URL() requires a protocol; callers often paste bare domains.
+    // URL() requires a protocol; callers often paste bare domains / IPs.
     if (!/^\w*:\/\//.test(url)) {
-        url = "http://" + url;
+        const pathStart = url.indexOf("/");
+        const hostPort = pathStart === -1 ? url : url.slice(0, pathStart);
+        const path = pathStart === -1 ? "" : url.slice(pathStart);
+
+        // Bare IPv6 needs brackets. Domain:port and IPv4:port must not be bracketed.
+        // IPv6 always has at least two colons (`::1`, `2001:db8::1`); hostname:port has one.
+        const isIPv4WithOptionalPort = /^(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?$/.test(hostPort);
+        const colonCount = (hostPort.match(/:/g) || []).length;
+        const isBareIPv6 = !hostPort.startsWith("[") && !isIPv4WithOptionalPort && colonCount >= 2;
+
+        url = isBareIPv6 ? `http://[${hostPort}]${path}` : `http://${hostPort}${path}`;
     }
 
     return new URL(url).host;
 }
 
 /**
+ * True when `entry` is a valid IPv4 or IPv6 CIDR allowlist value.
+ * @param {string} entry
+ */
+export function isCIDRAllowlistEntry(entry) {
+    const slashIndex = entry.lastIndexOf("/");
+    if (slashIndex <= 0 || slashIndex === entry.length - 1) {
+        return false;
+    }
+
+    const network = entry.slice(0, slashIndex);
+    const prefix = Number(entry.slice(slashIndex + 1));
+    if (!Number.isInteger(prefix)) {
+        return false;
+    }
+
+    const bareNetwork = normalizeHostname(network);
+    const octets = parseIPv4Octets(bareNetwork);
+    if (octets) {
+        return prefix >= 0 && prefix <= 32;
+    }
+
+    if (bareNetwork.includes(":")) {
+        return prefix >= 0 && prefix <= 128 && expandIPv6(bareNetwork) !== null;
+    }
+
+    return false;
+}
+
+/**
+ * True when an allowlist entry is an IP address (no port) or a CIDR range.
+ * Domain entries and host:port IP entries return false.
+ * @param {string} entry
+ */
+export function isIPOrCIDREntry(entry) {
+    if (isCIDRAllowlistEntry(entry)) {
+        return true;
+    }
+
+    try {
+        const entryUrl = new URL(`http://${entry}/`);
+        return entryUrl.host === entryUrl.hostname && isLiteralIpHostname(entryUrl.hostname);
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Normalize and validate a user-supplied allowlist entry.
+ * Accepts domains, IP addresses (with optional port), and CIDR ranges.
+ * @param {string} input
+ * @returns {string}
+ * @throws {Error} When the entry is empty or invalid
+ */
+export function normalizeAllowlistEntry(input) {
+    input = String(input ?? "").trim();
+    if (!input) {
+        throw new Error("empty allowlist entry");
+    }
+
+    // CIDR must be accepted before URL parsing — otherwise `192.168.1.0/24`
+    // becomes host `192.168.1.0` with path `/24`.
+    if (input.includes("/")) {
+        if (!isCIDRAllowlistEntry(input)) {
+            throw new Error("invalid CIDR notation");
+        }
+        const slashIndex = input.lastIndexOf("/");
+        const network = normalizeHostname(input.slice(0, slashIndex));
+        const prefix = input.slice(slashIndex + 1);
+        // Store IPv6 networks without brackets for stable compares.
+        return `${network}/${prefix}`;
+    }
+
+    return extractURLHost(input);
+}
+
+/**
+ * Treat `localhost` as loopback for IP allowlist comparisons.
+ * @param {string} hostname
+ */
+function normalizeLoopbackHostname(hostname) {
+    const bare = normalizeHostname(hostname);
+    return bare === "localhost" ? "127.0.0.1" : bare;
+}
+
+function hostnameFromHost(host) {
+    try {
+        return new URL(`http://${host}/`).hostname;
+    } catch {
+        return host;
+    }
+}
+
+function ipv4ToInt(ip) {
+    const parts = parseIPv4Octets(ip);
+    if (!parts) return null;
+    return ((parts[0] << 24) >>> 0) + (parts[1] << 16) + (parts[2] << 8) + parts[3];
+}
+
+function ipv6ToBigInt(ip) {
+    const hextets = expandIPv6(ip);
+    if (!hextets) return null;
+
+    let value = 0n;
+    for (const part of hextets) {
+        value = (value << 16n) + BigInt(part);
+    }
+    return value;
+}
+
+/**
+ * True when `ip` falls within the CIDR network.
+ * @param {string} ip Hostname/IP without port (brackets optional)
+ * @param {string} cidr e.g. `192.168.1.0/24` or `fe80::/10`
+ */
+export function ipInCIDR(ip, cidr) {
+    const bareIp = normalizeHostname(ip);
+    const slashIndex = cidr.lastIndexOf("/");
+    if (slashIndex <= 0) return false;
+
+    const network = normalizeHostname(cidr.slice(0, slashIndex));
+    const prefix = Number(cidr.slice(slashIndex + 1));
+    if (!Number.isInteger(prefix)) return false;
+
+    const ipInt = ipv4ToInt(bareIp);
+    const networkInt = ipv4ToInt(network);
+    if (ipInt !== null && networkInt !== null) {
+        if (prefix < 0 || prefix > 32) return false;
+        const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0;
+        return (ipInt & mask) === (networkInt & mask);
+    }
+
+    const ipBig = ipv6ToBigInt(bareIp);
+    const networkBig = ipv6ToBigInt(network);
+    if (ipBig !== null && networkBig !== null) {
+        if (prefix < 0 || prefix > 128) return false;
+        const mask = prefix === 0 ? 0n : ((1n << 128n) - 1n) << BigInt(128 - prefix);
+        return (ipBig & mask) === (networkBig & mask);
+    }
+
+    return false;
+}
+
+/**
+ * Returns whether an origin/request host matches a single allowlist entry.
+ * Domains require an exact `URL.host` match (subdomains are not implied).
+ * IP addresses without an explicit port also match the same address on any port
+ * (e.g. `127.0.0.1` matches `127.0.0.1:8080`). CIDR entries match any IP in range.
+ * `localhost` is treated as equivalent to `127.0.0.1`.
+ * @param {string} host `URL.host` of the page origin or request target
+ * @param {string} allowlistEntry A stored allowlist entry
+ */
+export function hostMatchesAllowlistEntry(host, allowlistEntry) {
+    if (host === allowlistEntry) {
+        return true;
+    }
+
+    if (isCIDRAllowlistEntry(allowlistEntry)) {
+        const hostname = normalizeLoopbackHostname(hostnameFromHost(host));
+        return ipInCIDR(hostname, allowlistEntry);
+    }
+
+    let hostUrl;
+    let entryUrl;
+    try {
+        hostUrl = new URL(`http://${host}/`);
+        entryUrl = new URL(`http://${allowlistEntry}/`);
+    } catch {
+        return false;
+    }
+
+    const hostHostname = normalizeLoopbackHostname(hostUrl.hostname);
+    const entryHostname = normalizeLoopbackHostname(entryUrl.hostname);
+
+    // Portless IP entry: match the same address on any port.
+    if (entryUrl.host === entryUrl.hostname && isLiteralIpHostname(entryUrl.hostname)) {
+        return hostHostname === entryHostname;
+    }
+
+    return false;
+}
+
+/**
  * Exact host match against the allowlist (subdomains are not implicitly allowed).
+ * Also honors portless IP entries and CIDR ranges for the given host.
  * @param {string} originHost `URL.host` of the requesting page
  * @param {string[]} allowedDomains
  */
 export function isHostAllowlisted(originHost, allowedDomains) {
-    return allowedDomains.some((domain) => originHost === domain);
+    return allowedDomains.some((entry) => hostMatchesAllowlistEntry(originHost, entry));
+}
+
+/**
+ * Whether a request should bypass blocking based on the allowlist.
+ * Domain entries only match the page origin. IP and CIDR entries also match
+ * request destinations so trusted addresses can be reached (e.g. from file://).
+ * @param {string} originHost `URL.host` of the requesting page
+ * @param {string|null|undefined} requestHost `URL.host` of the request target
+ * @param {string[]} allowlist
+ */
+export function requestMatchesAllowlist(originHost, requestHost, allowlist) {
+    return allowlist.some((entry) => {
+        if (hostMatchesAllowlistEntry(originHost, entry)) {
+            return true;
+        }
+
+        if (!requestHost || !isIPOrCIDREntry(entry)) {
+            return false;
+        }
+
+        return hostMatchesAllowlistEntry(requestHost, entry);
+    });
 }

--- a/global/allowlist.js
+++ b/global/allowlist.js
@@ -160,9 +160,9 @@ export function normalizeAllowlistEntry(input) {
 }
 
 /**
- * Interpret a paste as CIDR when URL parsing yields an IP hostname whose first
- * path segment is a prefix length (e.g. `http://192.168.1.0/24/dashboard` →
- * pathname `/24/dashboard`).
+ * Interpret a paste as CIDR only when the URL path is exactly a prefix length
+ * (`/24` or `/24/`). Extra path segments mean a normal page URL — store the
+ * host, not a subnet (e.g. `http://192.168.1.50/24/items` → `192.168.1.50`).
  * @param {string} input
  * @returns {string|null}
  */
@@ -179,26 +179,19 @@ function extractLeadingCidr(input) {
         return null;
     }
 
-    // pathname: "/24", "/24/dashboard", "/8080/status", or "/"
-    const firstSegment = parsed.pathname.split("/").find((part) => part.length > 0);
-    if (!firstSegment || !isAllDigits(firstSegment)) {
+    // Exactly one path segment, all digits — otherwise this is not CIDR notation.
+    const segments = parsed.pathname.split("/").filter((part) => part.length > 0);
+    if (segments.length !== 1 || !isAllDigits(segments[0])) {
         return null;
     }
 
-    const candidate = `${bareNetwork}/${firstSegment}`;
+    const candidate = `${bareNetwork}/${segments[0]}`;
     if (isCIDRAllowlistEntry(candidate)) {
         return candidate;
     }
 
-    // Near-miss prefixes are CIDR typos (`/33`, `/129`). Much larger numbers are
-    // normal URL paths (e.g. http://127.0.0.1/8080/status).
-    const prefixNum = Number(firstSegment);
-    const isV4 = parseIPv4Octets(bareNetwork) !== null;
-    const maxPrefix = isV4 ? 32 : 128;
-    if (prefixNum <= maxPrefix * 2) {
-        throw new Error("invalid CIDR notation");
-    }
-    return null;
+    // Exact `ip/N` with an out-of-range prefix is a CIDR typo, not a page path.
+    throw new Error("invalid CIDR notation");
 }
 
 /**

--- a/global/allowlist.js
+++ b/global/allowlist.js
@@ -77,7 +77,9 @@ export function isIPOrCIDREntry(entry) {
 
     try {
         const entryUrl = new URL(`http://${entry}/`);
-        return entryUrl.host === entryUrl.hostname && isLiteralIpHostname(entryUrl.hostname);
+        // Use `.port` (not host===hostname): IPv6 brackets can make host≠hostname
+        // in some URL implementations.
+        return entryUrl.port === "" && isLiteralIpHostname(entryUrl.hostname);
     } catch {
         return false;
     }
@@ -96,16 +98,17 @@ export function normalizeAllowlistEntry(input) {
         throw new Error("empty allowlist entry");
     }
 
-    // Only treat slash-containing input as CIDR when the network side is an IP.
-    // Full URLs (`https://example.com/path`) and bare hosts with paths
-    // (`discord.com/invite`) must still go through extractURLHost.
-    if (looksLikeCidrAttempt(input)) {
-        if (!isCIDRAllowlistEntry(input)) {
+    // Allow paste mistakes like `http://192.168.1.0/24` or `192.168.1.0/24/`.
+    // Strip scheme + trailing slashes only for the CIDR candidate check so
+    // normal URLs/paths still fall through to extractURLHost.
+    const cidrCandidate = input.replace(/^\w+:\/\//, "").replace(/\/+$/, "");
+    if (looksLikeCidrAttempt(cidrCandidate)) {
+        if (!isCIDRAllowlistEntry(cidrCandidate)) {
             throw new Error("invalid CIDR notation");
         }
-        const slashIndex = input.lastIndexOf("/");
-        const network = normalizeHostname(input.slice(0, slashIndex));
-        const prefix = input.slice(slashIndex + 1);
+        const slashIndex = cidrCandidate.lastIndexOf("/");
+        const network = normalizeHostname(cidrCandidate.slice(0, slashIndex));
+        const prefix = cidrCandidate.slice(slashIndex + 1);
         // Store IPv6 networks without brackets for stable compares.
         return `${network}/${prefix}`;
     }
@@ -229,7 +232,9 @@ export function hostMatchesAllowlistEntry(host, allowlistEntry) {
     const entryHostname = canonicalizeAllowlistHostname(entryUrl.hostname);
 
     // Portless IP entry: match the same address on any port.
-    if (entryUrl.host === entryUrl.hostname && isLiteralIpHostname(entryUrl.hostname)) {
+    // Check `.port` rather than host===hostname — IPv6 bracket handling differs
+    // across URL implementations (Node keeps brackets on hostname; some browsers omit them).
+    if (entryUrl.port === "" && isLiteralIpHostname(entryUrl.hostname)) {
         return hostHostname === entryHostname;
     }
 

--- a/global/allowlist.js
+++ b/global/allowlist.js
@@ -132,10 +132,19 @@ function extractLeadingCidr(input) {
     if (!isIpNetwork) return null;
 
     const candidate = `${bareNetwork}/${prefixMatch[1]}`;
-    if (!isCIDRAllowlistEntry(candidate)) {
+    if (isCIDRAllowlistEntry(candidate)) {
+        return candidate;
+    }
+
+    // Near-miss prefixes are CIDR typos (`/33`, `/129`). Much larger numbers are
+    // treated as normal URL paths (e.g. http://127.0.0.1/8080/status).
+    const prefixNum = Number(prefixMatch[1]);
+    const isV4 = parseIPv4Octets(bareNetwork) !== null;
+    const maxPrefix = isV4 ? 32 : 128;
+    if (prefixNum <= maxPrefix * 2) {
         throw new Error("invalid CIDR notation");
     }
-    return candidate;
+    return null;
 }
 
 /**

--- a/global/allowlist.js
+++ b/global/allowlist.js
@@ -3,8 +3,8 @@
  *
  * Parsing is URL-first via the URL API. CIDR is a special case because the URL
  * standard treats `/24` as a pathname, not a prefix length — so after a successful
- * URL parse we optionally interpret the first path segment as a CIDR prefix when
- * the hostname is an IP literal.
+ * URL parse we optionally interpret an exact single numeric path segment as a
+ * CIDR prefix when the hostname is an IP literal.
  */
 import {
     isLiteralIpHostname,
@@ -150,36 +150,26 @@ export function normalizeAllowlistEntry(input) {
         throw new Error("empty allowlist entry");
     }
 
-    // CIDR first: URL parsing alone cannot represent prefix lengths.
-    const leadingCidr = extractLeadingCidr(input);
-    if (leadingCidr) {
-        return leadingCidr;
+    const parsed = parseAllowlistUrl(input);
+    const cidr = cidrFromParsedUrl(parsed);
+    if (cidr) {
+        return cidr;
     }
-
-    return extractURLHost(input);
+    return parsed.host;
 }
 
 /**
- * Interpret a paste as CIDR only when the URL path is exactly a prefix length
- * (`/24` or `/24/`). Extra path segments mean a normal page URL — store the
- * host, not a subnet (e.g. `http://192.168.1.50/24/items` → `192.168.1.50`).
- * @param {string} input
+ * If `parsed` is an IP URL whose path is exactly a prefix length (`/24`),
+ * return normalized `network/prefix`. Extra path segments are not CIDR.
+ * @param {URL} parsed
  * @returns {string|null}
  */
-function extractLeadingCidr(input) {
-    let parsed;
-    try {
-        parsed = parseAllowlistUrl(input);
-    } catch {
-        return null;
-    }
-
+function cidrFromParsedUrl(parsed) {
     const bareNetwork = normalizeHostname(parsed.hostname);
     if (!isLiteralIpHostname(bareNetwork)) {
         return null;
     }
 
-    // Exactly one path segment, all digits — otherwise this is not CIDR notation.
     const segments = parsed.pathname.split("/").filter((part) => part.length > 0);
     if (segments.length !== 1 || !isAllDigits(segments[0])) {
         return null;

--- a/global/allowlist.js
+++ b/global/allowlist.js
@@ -1,5 +1,10 @@
 /**
  * Helpers for the domain/IP/CIDR allowlist used by settings UI and request filtering.
+ *
+ * Parsing is URL-first via the URL API. CIDR is a special case because the URL
+ * standard treats `/24` as a pathname, not a prefix length — so after a successful
+ * URL parse we optionally interpret the first path segment as a CIDR prefix when
+ * the hostname is an IP literal.
  */
 import {
     isLiteralIpHostname,
@@ -9,6 +14,70 @@ import {
     unwrapIpv4MappedAddress,
 } from "./privateAddress.js";
 
+function isAllDigits(value) {
+    if (!value) return false;
+    for (let i = 0; i < value.length; i++) {
+        const code = value.charCodeAt(i);
+        if (code < 48 || code > 57) return false;
+    }
+    return true;
+}
+
+function countChar(value, ch) {
+    let n = 0;
+    for (let i = 0; i < value.length; i++) {
+        if (value[i] === ch) n++;
+    }
+    return n;
+}
+
+/**
+ * Parse a user paste into a URL. Bare hosts/CIDRs get an `http://` scheme;
+ * bare IPv6 literals are bracketed so URL() accepts them.
+ * @param {string} input
+ * @returns {URL}
+ */
+function parseAllowlistUrl(input) {
+    input = input.trim();
+    const looksAbsolute = input.indexOf("://") > 0;
+
+    try {
+        const direct = new URL(input);
+        // Only trust absolute URLs that actually have a host. Some engines (notably
+        // Node) accept bare strings like `example.com:8080` or `fe80::/10` as
+        // opaque URLs with an empty host — those must use the bare-host path.
+        if (direct.host) {
+            return direct;
+        }
+        if (looksAbsolute) {
+            throw new TypeError("Invalid URL");
+        }
+    } catch (error) {
+        // Scheme-bearing input that failed to parse must not be reinterpreted as
+        // a bare host (e.g. `http://` → `http://http//`).
+        if (looksAbsolute) {
+            throw error instanceof TypeError ? error : new TypeError("Invalid URL");
+        }
+        // Otherwise fall through and treat as a bare host / CIDR / IPv6 literal.
+    }
+
+    const pathStart = input.indexOf("/");
+    const hostPort = pathStart === -1 ? input : input.slice(0, pathStart);
+    const path = pathStart === -1 ? "" : input.slice(pathStart);
+
+    if (hostPort.startsWith("[")) {
+        return new URL(`http://${hostPort}${path}`);
+    }
+
+    // Bare IPv6 has ≥2 colons. IPv4/hostname:port has at most one.
+    // (URL() rejects `http://::1` without brackets.)
+    if (countChar(hostPort, ":") >= 2) {
+        return new URL(`http://[${hostPort}]${path}`);
+    }
+
+    return new URL(`http://${hostPort}${path}`);
+}
+
 /**
  * Get a well-formed host to match against from a user-supplied URL-like string.
  * @param {string} url A URL-like value (eg `https://example.com/path`, `discord.com`, `example.com:8080`)
@@ -16,24 +85,7 @@ import {
  * @throws {TypeError} When the input cannot be parsed as a URL
  */
 export function extractURLHost(url) {
-    url = url.trim();
-
-    // URL() requires a protocol; callers often paste bare domains / IPs.
-    if (!/^\w*:\/\//.test(url)) {
-        const pathStart = url.indexOf("/");
-        const hostPort = pathStart === -1 ? url : url.slice(0, pathStart);
-        const path = pathStart === -1 ? "" : url.slice(pathStart);
-
-        // Bare IPv6 needs brackets. Domain:port and IPv4:port must not be bracketed.
-        // IPv6 always has at least two colons (`::1`, `2001:db8::1`); hostname:port has one.
-        const isIPv4WithOptionalPort = /^(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?$/.test(hostPort);
-        const colonCount = (hostPort.match(/:/g) || []).length;
-        const isBareIPv6 = !hostPort.startsWith("[") && !isIPv4WithOptionalPort && colonCount >= 2;
-
-        url = isBareIPv6 ? `http://[${hostPort}]${path}` : `http://${hostPort}${path}`;
-    }
-
-    return new URL(url).host;
+    return parseAllowlistUrl(url).host;
 }
 
 /**
@@ -98,8 +150,7 @@ export function normalizeAllowlistEntry(input) {
         throw new Error("empty allowlist entry");
     }
 
-    // Prefer a leading IP/prefix even when the paste includes a scheme or
-    // trailing path (e.g. `http://192.168.1.0/24/dashboard`).
+    // CIDR first: URL parsing alone cannot represent prefix lengths.
     const leadingCidr = extractLeadingCidr(input);
     if (leadingCidr) {
         return leadingCidr;
@@ -109,36 +160,39 @@ export function normalizeAllowlistEntry(input) {
 }
 
 /**
- * If `input` begins with a valid CIDR (optionally after a URL scheme, and
- * optionally followed by more path), return the normalized `network/prefix`.
- * Throws when the leading network is an IP but the prefix is invalid.
+ * Interpret a paste as CIDR when URL parsing yields an IP hostname whose first
+ * path segment is a prefix length (e.g. `http://192.168.1.0/24/dashboard` →
+ * pathname `/24/dashboard`).
  * @param {string} input
  * @returns {string|null}
  */
 function extractLeadingCidr(input) {
-    const withoutScheme = input.replace(/^\w+:\/\//, "").replace(/\/+$/, "");
-    const slashIndex = withoutScheme.indexOf("/");
-    if (slashIndex <= 0) return null;
+    let parsed;
+    try {
+        parsed = parseAllowlistUrl(input);
+    } catch {
+        return null;
+    }
 
-    const network = withoutScheme.slice(0, slashIndex);
-    const rest = withoutScheme.slice(slashIndex + 1);
-    const prefixMatch = rest.match(/^(\d+)/);
-    if (!prefixMatch) return null;
+    const bareNetwork = normalizeHostname(parsed.hostname);
+    if (!isLiteralIpHostname(bareNetwork)) {
+        return null;
+    }
 
-    const bareNetwork = normalizeHostname(network);
-    const isIpNetwork =
-        parseIPv4Octets(bareNetwork) !== null ||
-        (bareNetwork.includes(":") && expandIPv6(bareNetwork) !== null);
-    if (!isIpNetwork) return null;
+    // pathname: "/24", "/24/dashboard", "/8080/status", or "/"
+    const firstSegment = parsed.pathname.split("/").find((part) => part.length > 0);
+    if (!firstSegment || !isAllDigits(firstSegment)) {
+        return null;
+    }
 
-    const candidate = `${bareNetwork}/${prefixMatch[1]}`;
+    const candidate = `${bareNetwork}/${firstSegment}`;
     if (isCIDRAllowlistEntry(candidate)) {
         return candidate;
     }
 
     // Near-miss prefixes are CIDR typos (`/33`, `/129`). Much larger numbers are
-    // treated as normal URL paths (e.g. http://127.0.0.1/8080/status).
-    const prefixNum = Number(prefixMatch[1]);
+    // normal URL paths (e.g. http://127.0.0.1/8080/status).
+    const prefixNum = Number(firstSegment);
     const isV4 = parseIPv4Octets(bareNetwork) !== null;
     const maxPrefix = isV4 ? 32 : 128;
     if (prefixNum <= maxPrefix * 2) {

--- a/global/allowlist.js
+++ b/global/allowlist.js
@@ -6,6 +6,7 @@ import {
     normalizeHostname,
     parseIPv4Octets,
     expandIPv6,
+    unwrapIpv4MappedAddress,
 } from "./privateAddress.js";
 
 /**
@@ -95,9 +96,10 @@ export function normalizeAllowlistEntry(input) {
         throw new Error("empty allowlist entry");
     }
 
-    // CIDR must be accepted before URL parsing — otherwise `192.168.1.0/24`
-    // becomes host `192.168.1.0` with path `/24`.
-    if (input.includes("/")) {
+    // Only treat slash-containing input as CIDR when the network side is an IP.
+    // Full URLs (`https://example.com/path`) and bare hosts with paths
+    // (`discord.com/invite`) must still go through extractURLHost.
+    if (looksLikeCidrAttempt(input)) {
         if (!isCIDRAllowlistEntry(input)) {
             throw new Error("invalid CIDR notation");
         }
@@ -112,12 +114,29 @@ export function normalizeAllowlistEntry(input) {
 }
 
 /**
- * Treat `localhost` as loopback for IP allowlist comparisons.
+ * True when input looks like `IP/prefix` rather than a URL or host/path.
+ * @param {string} input
+ */
+function looksLikeCidrAttempt(input) {
+    if (!input.includes("/")) return false;
+    // Scheme-bearing URLs are never CIDR entries.
+    if (/^\w+:\/\//.test(input)) return false;
+
+    const slashIndex = input.lastIndexOf("/");
+    if (slashIndex <= 0 || slashIndex === input.length - 1) return false;
+
+    const bareNetwork = normalizeHostname(input.slice(0, slashIndex));
+    if (parseIPv4Octets(bareNetwork)) return true;
+    return bareNetwork.includes(":") && expandIPv6(bareNetwork) !== null;
+}
+
+/**
+ * Canonical hostname for IP allowlist compares: unwrap mapped IPv6, map localhost → 127.0.0.1.
  * @param {string} hostname
  */
-function normalizeLoopbackHostname(hostname) {
-    const bare = normalizeHostname(hostname);
-    return bare === "localhost" ? "127.0.0.1" : bare;
+function canonicalizeAllowlistHostname(hostname) {
+    const unwrapped = unwrapIpv4MappedAddress(hostname);
+    return unwrapped === "localhost" ? "127.0.0.1" : unwrapped;
 }
 
 function hostnameFromHost(host) {
@@ -151,7 +170,7 @@ function ipv6ToBigInt(ip) {
  * @param {string} cidr e.g. `192.168.1.0/24` or `fe80::/10`
  */
 export function ipInCIDR(ip, cidr) {
-    const bareIp = normalizeHostname(ip);
+    const bareIp = canonicalizeAllowlistHostname(ip);
     const slashIndex = cidr.lastIndexOf("/");
     if (slashIndex <= 0) return false;
 
@@ -193,7 +212,7 @@ export function hostMatchesAllowlistEntry(host, allowlistEntry) {
     }
 
     if (isCIDRAllowlistEntry(allowlistEntry)) {
-        const hostname = normalizeLoopbackHostname(hostnameFromHost(host));
+        const hostname = canonicalizeAllowlistHostname(hostnameFromHost(host));
         return ipInCIDR(hostname, allowlistEntry);
     }
 
@@ -206,8 +225,8 @@ export function hostMatchesAllowlistEntry(host, allowlistEntry) {
         return false;
     }
 
-    const hostHostname = normalizeLoopbackHostname(hostUrl.hostname);
-    const entryHostname = normalizeLoopbackHostname(entryUrl.hostname);
+    const hostHostname = canonicalizeAllowlistHostname(hostUrl.hostname);
+    const entryHostname = canonicalizeAllowlistHostname(entryUrl.hostname);
 
     // Portless IP entry: match the same address on any port.
     if (entryUrl.host === entryUrl.hostname && isLiteralIpHostname(entryUrl.hostname)) {

--- a/global/allowlist.js
+++ b/global/allowlist.js
@@ -98,39 +98,44 @@ export function normalizeAllowlistEntry(input) {
         throw new Error("empty allowlist entry");
     }
 
-    // Allow paste mistakes like `http://192.168.1.0/24` or `192.168.1.0/24/`.
-    // Strip scheme + trailing slashes only for the CIDR candidate check so
-    // normal URLs/paths still fall through to extractURLHost.
-    const cidrCandidate = input.replace(/^\w+:\/\//, "").replace(/\/+$/, "");
-    if (looksLikeCidrAttempt(cidrCandidate)) {
-        if (!isCIDRAllowlistEntry(cidrCandidate)) {
-            throw new Error("invalid CIDR notation");
-        }
-        const slashIndex = cidrCandidate.lastIndexOf("/");
-        const network = normalizeHostname(cidrCandidate.slice(0, slashIndex));
-        const prefix = cidrCandidate.slice(slashIndex + 1);
-        // Store IPv6 networks without brackets for stable compares.
-        return `${network}/${prefix}`;
+    // Prefer a leading IP/prefix even when the paste includes a scheme or
+    // trailing path (e.g. `http://192.168.1.0/24/dashboard`).
+    const leadingCidr = extractLeadingCidr(input);
+    if (leadingCidr) {
+        return leadingCidr;
     }
 
     return extractURLHost(input);
 }
 
 /**
- * True when input looks like `IP/prefix` rather than a URL or host/path.
+ * If `input` begins with a valid CIDR (optionally after a URL scheme, and
+ * optionally followed by more path), return the normalized `network/prefix`.
+ * Throws when the leading network is an IP but the prefix is invalid.
  * @param {string} input
+ * @returns {string|null}
  */
-function looksLikeCidrAttempt(input) {
-    if (!input.includes("/")) return false;
-    // Scheme-bearing URLs are never CIDR entries.
-    if (/^\w+:\/\//.test(input)) return false;
+function extractLeadingCidr(input) {
+    const withoutScheme = input.replace(/^\w+:\/\//, "").replace(/\/+$/, "");
+    const slashIndex = withoutScheme.indexOf("/");
+    if (slashIndex <= 0) return null;
 
-    const slashIndex = input.lastIndexOf("/");
-    if (slashIndex <= 0 || slashIndex === input.length - 1) return false;
+    const network = withoutScheme.slice(0, slashIndex);
+    const rest = withoutScheme.slice(slashIndex + 1);
+    const prefixMatch = rest.match(/^(\d+)/);
+    if (!prefixMatch) return null;
 
-    const bareNetwork = normalizeHostname(input.slice(0, slashIndex));
-    if (parseIPv4Octets(bareNetwork)) return true;
-    return bareNetwork.includes(":") && expandIPv6(bareNetwork) !== null;
+    const bareNetwork = normalizeHostname(network);
+    const isIpNetwork =
+        parseIPv4Octets(bareNetwork) !== null ||
+        (bareNetwork.includes(":") && expandIPv6(bareNetwork) !== null);
+    if (!isIpNetwork) return null;
+
+    const candidate = `${bareNetwork}/${prefixMatch[1]}`;
+    if (!isCIDRAllowlistEntry(candidate)) {
+        throw new Error("invalid CIDR notation");
+    }
+    return candidate;
 }
 
 /**

--- a/global/privateAddress.js
+++ b/global/privateAddress.js
@@ -188,6 +188,12 @@ export function unwrapIpv4MappedAddress(hostname) {
     const bare = normalizeHostname(hostname);
     const hextets = expandIPv6(bare);
     if (!hextets) return bare;
+
+    // :: and ::1 are reserved; they share the deprecated IPv4-compatible
+    // ::/96 prefix but must not unwrap to 0.0.0.0 / 0.0.0.1.
+    if (hextets.every((h) => h === 0)) return bare;
+    if (hextets.every((h, i) => (i === 7 ? h === 1 : h === 0))) return bare;
+
     if (isIpv4MappedHextets(hextets) || isIpv4CompatibleHextets(hextets)) {
         return ipv4FromHextets(hextets[6], hextets[7]);
     }

--- a/global/privateAddress.js
+++ b/global/privateAddress.js
@@ -179,6 +179,22 @@ export function isLiteralIpHostname(hostname) {
 }
 
 /**
+ * If `hostname` is an IPv4-mapped or IPv4-compatible IPv6 literal, return the
+ * embedded dotted IPv4 address. Otherwise return the normalized hostname.
+ * @param {string} hostname
+ * @returns {string}
+ */
+export function unwrapIpv4MappedAddress(hostname) {
+    const bare = normalizeHostname(hostname);
+    const hextets = expandIPv6(bare);
+    if (!hextets) return bare;
+    if (isIpv4MappedHextets(hextets) || isIpv4CompatibleHextets(hextets)) {
+        return ipv4FromHextets(hextets[6], hextets[7]);
+    }
+    return bare;
+}
+
+/**
  * Returns true when `url` targets a local/private address over a supported protocol.
  * Alternate IPv4 encodings (integer/hex/octal/short-form) are normalized by the
  * URL parser into dotted-decimal before this check runs.

--- a/global/privateAddress.js
+++ b/global/privateAddress.js
@@ -10,7 +10,7 @@ const LOCAL_REQUEST_PROTOCOLS = new Set([
 ]);
 
 /** @returns {number[]|null} four octets, or null if not a dotted IPv4 literal */
-function parseIPv4Octets(ip) {
+export function parseIPv4Octets(ip) {
     const parts = ip.split(".");
     if (parts.length !== 4) return null;
     const octets = parts.map(Number);
@@ -45,7 +45,7 @@ function isPrivateIPv4(ip) {
  * Accepts compressed form, zone IDs, and dotted IPv4 tails (::ffff:127.0.0.1).
  * @returns {number[]|null}
  */
-function expandIPv6(ip) {
+export function expandIPv6(ip) {
     let addr = ip.toLowerCase().split("%")[0];
 
     // Convert a trailing dotted-quad into two hextets before expansion.

--- a/global/requestFilter.js
+++ b/global/requestFilter.js
@@ -2,7 +2,7 @@
  * Decision logic for whether a request should be blocked.
  * Kept free of badge/notification/storage side effects so it can be unit tested.
  */
-import { isHostAllowlisted } from "./allowlist.js";
+import { requestMatchesAllowlist } from "./allowlist.js";
 import {
     isLocalRequestUrl,
     isLiteralIpHostname,
@@ -233,16 +233,18 @@ export async function evaluateRequest(requestDetails, deps) {
         return { cancel: false, reason: "unparseable-origin" };
     }
 
-    const allowedDomains = await getAllowedDomains();
-    if (isHostAllowlisted(originUrl.host, allowedDomains)) {
-        return { cancel: false, reason: "allowlisted" };
-    }
-
     let url;
     try {
         url = new URL(requestDetails.url);
     } catch {
         return { cancel: false, reason: "unparseable-url" };
+    }
+
+    const allowedDomains = await getAllowedDomains();
+    // Domains match the page origin only. IP/CIDR entries also match destinations
+    // so allowlisting 127.0.0.1 works for scans from file:// or other pages.
+    if (requestMatchesAllowlist(originUrl.host, url.host, allowedDomains)) {
+        return { cancel: false, reason: "allowlisted" };
     }
 
     const requestHost = normalizeHostname(url.hostname);

--- a/settings/settings.html
+++ b/settings/settings.html
@@ -15,15 +15,16 @@
     <main>
         <section class="panel" aria-labelledby="allowlist-heading">
             <div class="panel-intro">
-                <h2 id="allowlist-heading">Domain Allowlist</h2>
+                <h2 id="allowlist-heading">Allowlist</h2>
                 <p class="panel-copy">
-                    Allowed domains can make local requests and load LexisNexis tracking scripts without being blocked.
+                    Allowed domains, IP addresses, and CIDR ranges can make local requests and load LexisNexis tracking scripts without being blocked.
+                    Domains match the page making the request. IP and CIDR entries also allow connections to those addresses.
                 </p>
             </div>
 
             <form id="allowlist_add_form" class="add-form">
                 <label class="field" for="add_domain">
-                    <span class="field-label">Allow a domain</span>
+                    <span class="field-label">Allow a domain, IP, or CIDR range</span>
                     <input
                         type="text"
                         id="add_domain"
@@ -31,19 +32,19 @@
                         required
                         autocomplete="off"
                         spellcheck="false"
-                        placeholder="discord.com"
+                        placeholder="discord.com, 127.0.0.1, or 192.168.1.0/24"
                         aria-describedby="domain-hint"
                     >
                 </label>
                 <p id="domain-hint" class="field-hint">
-                    Enter a proper domain name, for example <code>discord.com</code>.
+                    Examples: <code>discord.com</code>, <code>127.0.0.1</code>, <code>192.168.1.0/24</code>.
                 </p>
-                <button type="submit" class="primary-button">Add domain</button>
+                <button type="submit" class="primary-button">Add entry</button>
             </form>
         </section>
 
         <section id="allowlist_section" class="panel" hidden>
-            <h2>Allowed Domains</h2>
+            <h2>Allowed Entries</h2>
             <ul id="allowlist_contents" class="selectable domain-list">
                 <!-- Dynamically Populated -->
             </ul>

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -1,6 +1,6 @@
 import { getItemFromLocal, modifyItemInLocal } from "../global/BrowserStorageManager.js";
 import { createElement } from "../global/domUtils.js";
-import { extractURLHost } from "../global/allowlist.js";
+import { normalizeAllowlistEntry } from "../global/allowlist.js";
 
 /**
  * A single item in the allowlist display
@@ -82,10 +82,10 @@ function allowlist_add_listener(event) {
     const form_url = allowlist_add_form.elements["add_domain"];
     let url = form_url.value;
     try {
-        url = extractURLHost(url);
+        url = normalizeAllowlistEntry(url);
     } catch(error) {
-        console.warn("Error parsing a domain to add to the allowlist:", {url, error});
-        alert("Please enter a valid domain.");
+        console.warn("Error parsing an allowlist entry:", {url, error});
+        alert("Please enter a valid domain, IP address, or CIDR range.");
         return;
     }
     
@@ -99,7 +99,7 @@ function allowlist_add_listener(event) {
             if (!list.includes(url)) {
                 return list.concat(url);
             } else {
-                alert("This domain is already in the list.");
+                alert("This entry is already in the list.");
                 return list;
             }
         }).then(

--- a/tests/allowlist.test.js
+++ b/tests/allowlist.test.js
@@ -60,6 +60,8 @@ export async function run() {
     await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("fe80::/129")), "bad IPv6 prefix throws");
     await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("http://192.168.1.0/33")), "scheme + bad prefix throws");
     await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("192.168.1.0/33/x")), "bad prefix with path throws");
+    assertEqual(normalizeAllowlistEntry("http://127.0.0.1/8080/status"), "127.0.0.1", "numeric URL path is not CIDR");
+    assertEqual(normalizeAllowlistEntry("127.0.0.1/8080"), "127.0.0.1", "large numeric path segment is not CIDR");
 
 
     suite("isCIDRAllowlistEntry / isIPOrCIDREntry");

--- a/tests/allowlist.test.js
+++ b/tests/allowlist.test.js
@@ -27,6 +27,10 @@ export async function run() {
     assertEqual(extractURLHost("http://[::1]:8080/"), "[::1]:8080", "IPv6 with port");
     assertEqual(extractURLHost("::1"), "[::1]", "bare IPv6 gets brackets");
     assertEqual(extractURLHost("[::1]"), "[::1]", "already-bracketed IPv6");
+    assertEqual(extractURLHost("[::1]:8080"), "[::1]:8080", "bracketed IPv6 with port");
+    // Bare `::1:8080` is a valid IPv6 address (last hextet 8080), not loopback:port.
+    // Port-specific IPv6 allowlist entries must use [addr]:port form.
+    assertEqual(extractURLHost("::1:8080"), "[::1:8080]", "bare IPv6-looking:port is an address");
     assertEqual(extractURLHost("HTTPS://EXAMPLE.COM/Path"), "example.com", "hostname lowercased by URL");
 
     suite("extractURLHost rejects invalid input");

--- a/tests/allowlist.test.js
+++ b/tests/allowlist.test.js
@@ -47,11 +47,15 @@ export async function run() {
     assertEqual(normalizeAllowlistEntry("10.0.0.0/8"), "10.0.0.0/8", "IPv4 /8 CIDR");
     assertEqual(normalizeAllowlistEntry("fe80::/10"), "fe80::/10", "IPv6 CIDR");
     assertEqual(normalizeAllowlistEntry("[fe80::]/10"), "fe80::/10", "bracketed IPv6 CIDR normalized");
+    assertEqual(normalizeAllowlistEntry("http://192.168.1.0/24"), "192.168.1.0/24", "scheme-prefixed CIDR");
+    assertEqual(normalizeAllowlistEntry("192.168.1.0/24/"), "192.168.1.0/24", "CIDR with trailing slash");
+    assertEqual(normalizeAllowlistEntry("https://10.0.0.0/8"), "10.0.0.0/8", "https-prefixed CIDR");
     assertEqual(normalizeAllowlistEntry("example.com/24"), "example.com", "domain with path-like slash is not CIDR");
     assertEqual(normalizeAllowlistEntry("not-a-cidr/24"), "not-a-cidr", "non-IP slash is treated as host/path");
     await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("")), "empty throws");
     await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("192.168.1.0/33")), "bad IPv4 prefix throws");
     await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("fe80::/129")), "bad IPv6 prefix throws");
+    await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("http://192.168.1.0/33")), "scheme + bad prefix throws");
 
 
     suite("isCIDRAllowlistEntry / isIPOrCIDREntry");
@@ -66,6 +70,7 @@ export async function run() {
     assert(isIPOrCIDREntry("192.168.1.0/24") === true, "CIDR is IP-or-CIDR");
     assert(isIPOrCIDREntry("example.com") === false, "domain is not IP-or-CIDR");
     assert(isIPOrCIDREntry("[::1]") === true, "portless IPv6");
+    assert(isIPOrCIDREntry("[::1]:8080") === false, "IPv6 with port is not open IP entry");
 
     suite("ipInCIDR");
     assert(ipInCIDR("192.168.1.50", "192.168.1.0/24") === true, "in /24");
@@ -100,6 +105,12 @@ export async function run() {
     assert(isHostAllowlisted("localhost:3000", ["127.0.0.1"]) === true, "localhost matches 127.0.0.1 entry");
     assert(isHostAllowlisted("127.0.0.1:3000", ["localhost"]) === false, "localhost entry is domain-exact (no port wildcard)");
     assert(hostMatchesAllowlistEntry("[::1]:8080", "[::1]") === true, "portless IPv6 matches any port");
+    assert(hostMatchesAllowlistEntry("[::1]:8080", "[::1]:8080") === true, "IPv6:port exact");
+    assert(hostMatchesAllowlistEntry("[::1]:3000", "[::1]:8080") === false, "IPv6:port is port-sensitive");
+    assert(
+        requestMatchesAllowlist("evil.example", "[::1]:80", ["[::1]"]) === true,
+        "portless IPv6 entry matches destination"
+    );
     assert(hostMatchesAllowlistEntry("[::ffff:127.0.0.1]:80", "127.0.0.1") === true, "IPv4-mapped loopback matches 127.0.0.1");
     assert(hostMatchesAllowlistEntry("[::ffff:7f00:1]:80", "127.0.0.1") === true, "IPv4-mapped hex loopback matches 127.0.0.1");
     assert(isHostAllowlisted("[::ffff:192.168.1.50]:8006", ["192.168.1.0/24"]) === true, "IPv4-mapped address matches IPv4 CIDR");

--- a/tests/allowlist.test.js
+++ b/tests/allowlist.test.js
@@ -36,6 +36,10 @@ export async function run() {
 
     suite("normalizeAllowlistEntry domains and IPs");
     assertEqual(normalizeAllowlistEntry("discord.com"), "discord.com", "domain");
+    assertEqual(normalizeAllowlistEntry("https://example.com"), "example.com", "full URL with scheme");
+    assertEqual(normalizeAllowlistEntry("https://example.com/path"), "example.com", "full URL with path");
+    assertEqual(normalizeAllowlistEntry("discord.com/invite/abc"), "discord.com", "bare host with path");
+    assertEqual(normalizeAllowlistEntry("http://127.0.0.1:3000/"), "127.0.0.1:3000", "IP URL with port and trailing slash");
     assertEqual(normalizeAllowlistEntry("127.0.0.1"), "127.0.0.1", "IPv4");
     assertEqual(normalizeAllowlistEntry("127.0.0.1:8080"), "127.0.0.1:8080", "IPv4 with port");
     assertEqual(normalizeAllowlistEntry("::1"), "[::1]", "IPv6");
@@ -43,10 +47,12 @@ export async function run() {
     assertEqual(normalizeAllowlistEntry("10.0.0.0/8"), "10.0.0.0/8", "IPv4 /8 CIDR");
     assertEqual(normalizeAllowlistEntry("fe80::/10"), "fe80::/10", "IPv6 CIDR");
     assertEqual(normalizeAllowlistEntry("[fe80::]/10"), "fe80::/10", "bracketed IPv6 CIDR normalized");
+    assertEqual(normalizeAllowlistEntry("example.com/24"), "example.com", "domain with path-like slash is not CIDR");
+    assertEqual(normalizeAllowlistEntry("not-a-cidr/24"), "not-a-cidr", "non-IP slash is treated as host/path");
     await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("")), "empty throws");
     await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("192.168.1.0/33")), "bad IPv4 prefix throws");
-    await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("not-a-cidr/24")), "non-IP CIDR throws");
-    await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("example.com/24")), "domain CIDR throws");
+    await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("fe80::/129")), "bad IPv6 prefix throws");
+
 
     suite("isCIDRAllowlistEntry / isIPOrCIDREntry");
     assert(isCIDRAllowlistEntry("192.168.1.0/24") === true, "IPv4 CIDR");
@@ -94,6 +100,9 @@ export async function run() {
     assert(isHostAllowlisted("localhost:3000", ["127.0.0.1"]) === true, "localhost matches 127.0.0.1 entry");
     assert(isHostAllowlisted("127.0.0.1:3000", ["localhost"]) === false, "localhost entry is domain-exact (no port wildcard)");
     assert(hostMatchesAllowlistEntry("[::1]:8080", "[::1]") === true, "portless IPv6 matches any port");
+    assert(hostMatchesAllowlistEntry("[::ffff:127.0.0.1]:80", "127.0.0.1") === true, "IPv4-mapped loopback matches 127.0.0.1");
+    assert(hostMatchesAllowlistEntry("[::ffff:7f00:1]:80", "127.0.0.1") === true, "IPv4-mapped hex loopback matches 127.0.0.1");
+    assert(isHostAllowlisted("[::ffff:192.168.1.50]:8006", ["192.168.1.0/24"]) === true, "IPv4-mapped address matches IPv4 CIDR");
 
     suite("isHostAllowlisted CIDR matching (issue #64)");
     assert(isHostAllowlisted("192.168.1.50:8006", ["192.168.1.0/24"]) === true, "Proxmox-like origin in /24");

--- a/tests/allowlist.test.js
+++ b/tests/allowlist.test.js
@@ -50,12 +50,16 @@ export async function run() {
     assertEqual(normalizeAllowlistEntry("http://192.168.1.0/24"), "192.168.1.0/24", "scheme-prefixed CIDR");
     assertEqual(normalizeAllowlistEntry("192.168.1.0/24/"), "192.168.1.0/24", "CIDR with trailing slash");
     assertEqual(normalizeAllowlistEntry("https://10.0.0.0/8"), "10.0.0.0/8", "https-prefixed CIDR");
+    assertEqual(normalizeAllowlistEntry("http://192.168.1.0/24/dashboard"), "192.168.1.0/24", "CIDR with extra path keeps prefix");
+    assertEqual(normalizeAllowlistEntry("192.168.1.0/24/foo"), "192.168.1.0/24", "bare CIDR with extra path keeps prefix");
+    assertEqual(normalizeAllowlistEntry("fe80::/10/x"), "fe80::/10", "IPv6 CIDR with extra path keeps prefix");
     assertEqual(normalizeAllowlistEntry("example.com/24"), "example.com", "domain with path-like slash is not CIDR");
     assertEqual(normalizeAllowlistEntry("not-a-cidr/24"), "not-a-cidr", "non-IP slash is treated as host/path");
     await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("")), "empty throws");
     await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("192.168.1.0/33")), "bad IPv4 prefix throws");
     await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("fe80::/129")), "bad IPv6 prefix throws");
     await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("http://192.168.1.0/33")), "scheme + bad prefix throws");
+    await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("192.168.1.0/33/x")), "bad prefix with path throws");
 
 
     suite("isCIDRAllowlistEntry / isIPOrCIDREntry");
@@ -159,6 +163,9 @@ export async function run() {
     assertEqual(normalizeAllowlistEntry("http://192.168.1.0/24"), "192.168.1.0/24", "scheme CIDR keeps prefix");
     assertEqual(normalizeAllowlistEntry("192.168.1.0/24/"), "192.168.1.0/24", "trailing slash CIDR keeps prefix");
     assert(normalizeAllowlistEntry("http://192.168.1.0/24") !== "192.168.1.0", "scheme CIDR is not truncated to host");
+    // Bug: CIDR followed by extra path segments also dropped the prefix
+    assertEqual(normalizeAllowlistEntry("http://192.168.1.0/24/dashboard"), "192.168.1.0/24", "CIDR+path keeps prefix");
+    assertEqual(normalizeAllowlistEntry("fe80::/10/extra"), "fe80::/10", "IPv6 CIDR+path keeps prefix");
     // Bug: IPv4-mapped literals did not match IPv4/CIDR allowlist entries
     assert(ipInCIDR("::ffff:192.168.1.50", "192.168.1.0/24") === true, "mapped IPv6 in IPv4 CIDR");
     assert(ipInCIDR("[::ffff:7f00:1]", "127.0.0.0/8") === true, "mapped hex loopback in 127/8");

--- a/tests/allowlist.test.js
+++ b/tests/allowlist.test.js
@@ -50,18 +50,18 @@ export async function run() {
     assertEqual(normalizeAllowlistEntry("http://192.168.1.0/24"), "192.168.1.0/24", "scheme-prefixed CIDR");
     assertEqual(normalizeAllowlistEntry("192.168.1.0/24/"), "192.168.1.0/24", "CIDR with trailing slash");
     assertEqual(normalizeAllowlistEntry("https://10.0.0.0/8"), "10.0.0.0/8", "https-prefixed CIDR");
-    assertEqual(normalizeAllowlistEntry("http://192.168.1.0/24/dashboard"), "192.168.1.0/24", "CIDR with extra path keeps prefix");
-    assertEqual(normalizeAllowlistEntry("192.168.1.0/24/foo"), "192.168.1.0/24", "bare CIDR with extra path keeps prefix");
-    assertEqual(normalizeAllowlistEntry("fe80::/10/x"), "fe80::/10", "IPv6 CIDR with extra path keeps prefix");
+    // Extra path means a page URL, not a subnet allowlist entry
+    assertEqual(normalizeAllowlistEntry("http://192.168.1.50/24/items"), "192.168.1.50", "IP URL with path stores host only");
+    assertEqual(normalizeAllowlistEntry("192.168.1.0/24/foo"), "192.168.1.0", "CIDR-like path with extra segments stores host");
+    assertEqual(normalizeAllowlistEntry("fe80::/10/x"), "[fe80::]", "IPv6 URL with extra path stores host");
+    assertEqual(normalizeAllowlistEntry("http://127.0.0.1/8080/status"), "127.0.0.1", "numeric URL path stores host");
     assertEqual(normalizeAllowlistEntry("example.com/24"), "example.com", "domain with path-like slash is not CIDR");
     assertEqual(normalizeAllowlistEntry("not-a-cidr/24"), "not-a-cidr", "non-IP slash is treated as host/path");
     await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("")), "empty throws");
     await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("192.168.1.0/33")), "bad IPv4 prefix throws");
     await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("fe80::/129")), "bad IPv6 prefix throws");
     await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("http://192.168.1.0/33")), "scheme + bad prefix throws");
-    await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("192.168.1.0/33/x")), "bad prefix with path throws");
-    assertEqual(normalizeAllowlistEntry("http://127.0.0.1/8080/status"), "127.0.0.1", "numeric URL path is not CIDR");
-    assertEqual(normalizeAllowlistEntry("127.0.0.1/8080"), "127.0.0.1", "large numeric path segment is not CIDR");
+    await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("127.0.0.1/8080")), "exact invalid prefix throws");
 
 
     suite("isCIDRAllowlistEntry / isIPOrCIDREntry");
@@ -165,9 +165,8 @@ export async function run() {
     assertEqual(normalizeAllowlistEntry("http://192.168.1.0/24"), "192.168.1.0/24", "scheme CIDR keeps prefix");
     assertEqual(normalizeAllowlistEntry("192.168.1.0/24/"), "192.168.1.0/24", "trailing slash CIDR keeps prefix");
     assert(normalizeAllowlistEntry("http://192.168.1.0/24") !== "192.168.1.0", "scheme CIDR is not truncated to host");
-    // Bug: CIDR followed by extra path segments also dropped the prefix
-    assertEqual(normalizeAllowlistEntry("http://192.168.1.0/24/dashboard"), "192.168.1.0/24", "CIDR+path keeps prefix");
-    assertEqual(normalizeAllowlistEntry("fe80::/10/extra"), "fe80::/10", "IPv6 CIDR+path keeps prefix");
+    // Extra path on an IP URL is a page URL, not an expanded subnet
+    assertEqual(normalizeAllowlistEntry("http://192.168.1.50/24/items"), "192.168.1.50", "IP page URL does not become CIDR");
     // Bug: IPv4-mapped literals did not match IPv4/CIDR allowlist entries
     assert(ipInCIDR("::ffff:192.168.1.50", "192.168.1.0/24") === true, "mapped IPv6 in IPv4 CIDR");
     assert(ipInCIDR("[::ffff:7f00:1]", "127.0.0.0/8") === true, "mapped hex loopback in 127/8");

--- a/tests/allowlist.test.js
+++ b/tests/allowlist.test.js
@@ -150,4 +150,29 @@ export async function run() {
         requestMatchesAllowlist("192.168.1.50:8006", "192.168.1.50:8008", ["192.168.1.0/24"]) === true,
         "CIDR matches Proxmox origin"
     );
+
+    suite("review-fix regressions");
+    // Bug: any '/' was treated as CIDR and rejected valid URLs/paths
+    assertEqual(normalizeAllowlistEntry("https://discord.com/invite/x"), "discord.com", "URL with path not rejected as CIDR");
+    assertEqual(normalizeAllowlistEntry("http://127.0.0.1:8080/status"), "127.0.0.1:8080", "IP URL with path extracts host:port");
+    // Bug: scheme-prefixed / trailing-slash CIDR silently truncated to bare IP
+    assertEqual(normalizeAllowlistEntry("http://192.168.1.0/24"), "192.168.1.0/24", "scheme CIDR keeps prefix");
+    assertEqual(normalizeAllowlistEntry("192.168.1.0/24/"), "192.168.1.0/24", "trailing slash CIDR keeps prefix");
+    assert(normalizeAllowlistEntry("http://192.168.1.0/24") !== "192.168.1.0", "scheme CIDR is not truncated to host");
+    // Bug: IPv4-mapped literals did not match IPv4/CIDR allowlist entries
+    assert(ipInCIDR("::ffff:192.168.1.50", "192.168.1.0/24") === true, "mapped IPv6 in IPv4 CIDR");
+    assert(ipInCIDR("[::ffff:7f00:1]", "127.0.0.0/8") === true, "mapped hex loopback in 127/8");
+    assert(
+        requestMatchesAllowlist("evil.example", "[::ffff:127.0.0.1]:80", ["127.0.0.1"]) === true,
+        "mapped loopback destination matches IPv4 allowlist"
+    );
+    // Bug: portless IPv6 must not rely on host===hostname (bracket differences)
+    assert(isIPOrCIDREntry("[::1]") === true, "bracketed IPv6 is portless IP entry");
+    assert(isIPOrCIDREntry("[::1]:8080") === false, "IPv6 with port is not a destination wildcard entry");
+    assert(hostMatchesAllowlistEntry("[::1]:65535", "[::1]") === true, "IPv6 portless matches high port");
+    // Bug: ::1 must not unwrap to 0.0.0.1 via deprecated IPv4-compatible ::/96
+    assert(hostMatchesAllowlistEntry("0.0.0.1:80", "[::1]") === false, "::1 allowlist must not match 0.0.0.1");
+    assert(hostMatchesAllowlistEntry("[::1]:80", "0.0.0.1") === false, "0.0.0.1 allowlist must not match ::1");
+    assert(ipInCIDR("::1", "0.0.0.0/8") === false, "::1 is not in 0.0.0.0/8 via false unwrap");
+    assert(hostMatchesAllowlistEntry("[::1]:8080", "[::1]") === true, "::1 still matches itself on any port");
 }

--- a/tests/allowlist.test.js
+++ b/tests/allowlist.test.js
@@ -1,4 +1,13 @@
-import { extractURLHost, isHostAllowlisted } from "../global/allowlist.js";
+import {
+    extractURLHost,
+    isHostAllowlisted,
+    normalizeAllowlistEntry,
+    isCIDRAllowlistEntry,
+    isIPOrCIDREntry,
+    hostMatchesAllowlistEntry,
+    requestMatchesAllowlist,
+    ipInCIDR,
+} from "../global/allowlist.js";
 import { suite, assert, assertEqual, assertRejects } from "./harness.js";
 
 export async function run() {
@@ -13,7 +22,11 @@ export async function run() {
     assertEqual(extractURLHost("http://example.com:80/"), "example.com", "default http port dropped");
     assertEqual(extractURLHost("https://sub.domain.example.co.uk/x"), "sub.domain.example.co.uk", "multi-level domain");
     assertEqual(extractURLHost("http://127.0.0.1:3000/"), "127.0.0.1:3000", "IPv4 with port");
+    assertEqual(extractURLHost("127.0.0.1"), "127.0.0.1", "bare IPv4");
+    assertEqual(extractURLHost("127.0.0.1:3000"), "127.0.0.1:3000", "bare IPv4 with port");
     assertEqual(extractURLHost("http://[::1]:8080/"), "[::1]:8080", "IPv6 with port");
+    assertEqual(extractURLHost("::1"), "[::1]", "bare IPv6 gets brackets");
+    assertEqual(extractURLHost("[::1]"), "[::1]", "already-bracketed IPv6");
     assertEqual(extractURLHost("HTTPS://EXAMPLE.COM/Path"), "example.com", "hostname lowercased by URL");
 
     suite("extractURLHost rejects invalid input");
@@ -21,13 +34,100 @@ export async function run() {
     await assertRejects(() => Promise.resolve(extractURLHost("://")), "protocol-only throws");
     await assertRejects(() => Promise.resolve(extractURLHost("http://")), "empty host throws");
 
+    suite("normalizeAllowlistEntry domains and IPs");
+    assertEqual(normalizeAllowlistEntry("discord.com"), "discord.com", "domain");
+    assertEqual(normalizeAllowlistEntry("127.0.0.1"), "127.0.0.1", "IPv4");
+    assertEqual(normalizeAllowlistEntry("127.0.0.1:8080"), "127.0.0.1:8080", "IPv4 with port");
+    assertEqual(normalizeAllowlistEntry("::1"), "[::1]", "IPv6");
+    assertEqual(normalizeAllowlistEntry("192.168.1.0/24"), "192.168.1.0/24", "IPv4 CIDR preserved");
+    assertEqual(normalizeAllowlistEntry("10.0.0.0/8"), "10.0.0.0/8", "IPv4 /8 CIDR");
+    assertEqual(normalizeAllowlistEntry("fe80::/10"), "fe80::/10", "IPv6 CIDR");
+    assertEqual(normalizeAllowlistEntry("[fe80::]/10"), "fe80::/10", "bracketed IPv6 CIDR normalized");
+    await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("")), "empty throws");
+    await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("192.168.1.0/33")), "bad IPv4 prefix throws");
+    await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("not-a-cidr/24")), "non-IP CIDR throws");
+    await assertRejects(() => Promise.resolve(normalizeAllowlistEntry("example.com/24")), "domain CIDR throws");
+
+    suite("isCIDRAllowlistEntry / isIPOrCIDREntry");
+    assert(isCIDRAllowlistEntry("192.168.1.0/24") === true, "IPv4 CIDR");
+    assert(isCIDRAllowlistEntry("0.0.0.0/0") === true, "IPv4 /0");
+    assert(isCIDRAllowlistEntry("fe80::/10") === true, "IPv6 CIDR");
+    assert(isCIDRAllowlistEntry("192.168.1.0") === false, "IP alone not CIDR");
+    assert(isCIDRAllowlistEntry("example.com") === false, "domain not CIDR");
+    assert(isCIDRAllowlistEntry("192.168.1.0/33") === false, "invalid prefix");
+    assert(isIPOrCIDREntry("127.0.0.1") === true, "portless IPv4");
+    assert(isIPOrCIDREntry("127.0.0.1:8080") === false, "IPv4 with port is not open IP entry");
+    assert(isIPOrCIDREntry("192.168.1.0/24") === true, "CIDR is IP-or-CIDR");
+    assert(isIPOrCIDREntry("example.com") === false, "domain is not IP-or-CIDR");
+    assert(isIPOrCIDREntry("[::1]") === true, "portless IPv6");
+
+    suite("ipInCIDR");
+    assert(ipInCIDR("192.168.1.50", "192.168.1.0/24") === true, "in /24");
+    assert(ipInCIDR("192.168.2.50", "192.168.1.0/24") === false, "out of /24");
+    assert(ipInCIDR("10.1.2.3", "10.0.0.0/8") === true, "in /8");
+    assert(ipInCIDR("11.0.0.1", "10.0.0.0/8") === false, "out of /8");
+    assert(ipInCIDR("127.0.0.1", "127.0.0.0/8") === true, "loopback /8");
+    assert(ipInCIDR("8.8.8.8", "0.0.0.0/0") === true, "everything in /0");
+    assert(ipInCIDR("192.168.1.1", "192.168.1.1/32") === true, "exact /32");
+    assert(ipInCIDR("192.168.1.2", "192.168.1.1/32") === false, "other /32");
+    assert(ipInCIDR("fe80::1", "fe80::/10") === true, "IPv6 link-local in /10");
+    assert(ipInCIDR("2001:db8::1", "fe80::/10") === false, "doc IPv6 not in fe80::/10");
+    assert(ipInCIDR("example.com", "192.168.1.0/24") === false, "domain not in CIDR");
+
     suite("isHostAllowlisted exact match semantics");
     assert(isHostAllowlisted("example.com", ["example.com"]) === true, "exact match");
     assert(isHostAllowlisted("example.com", ["other.com", "example.com"]) === true, "match in list");
     assert(isHostAllowlisted("example.com", []) === false, "empty list");
     assert(isHostAllowlisted("sub.example.com", ["example.com"]) === false, "subdomain not implied");
     assert(isHostAllowlisted("example.com", ["sub.example.com"]) === false, "parent not matched by child entry");
-    assert(isHostAllowlisted("example.com:8443", ["example.com"]) === false, "port-sensitive");
+    assert(isHostAllowlisted("example.com:8443", ["example.com"]) === false, "port-sensitive domain");
     assert(isHostAllowlisted("example.com:8443", ["example.com:8443"]) === true, "host:port exact");
     assert(isHostAllowlisted("Example.Com", ["example.com"]) === false, "case-sensitive host compare (URL.host is lowercase)");
+
+    suite("isHostAllowlisted IP address matching (issue #66)");
+    assert(isHostAllowlisted("127.0.0.1", ["127.0.0.1"]) === true, "exact IPv4");
+    assert(isHostAllowlisted("127.0.0.1:8080", ["127.0.0.1"]) === true, "portless IP matches any port");
+    assert(isHostAllowlisted("127.0.0.1:3000", ["127.0.0.1"]) === true, "portless IP matches other port");
+    assert(isHostAllowlisted("127.0.0.1:8080", ["127.0.0.1:8080"]) === true, "IP:port exact");
+    assert(isHostAllowlisted("127.0.0.1:3000", ["127.0.0.1:8080"]) === false, "IP:port is port-sensitive");
+    assert(isHostAllowlisted("10.0.0.1:8080", ["127.0.0.1"]) === false, "different IP not matched");
+    assert(isHostAllowlisted("localhost:3000", ["127.0.0.1"]) === true, "localhost matches 127.0.0.1 entry");
+    assert(isHostAllowlisted("127.0.0.1:3000", ["localhost"]) === false, "localhost entry is domain-exact (no port wildcard)");
+    assert(hostMatchesAllowlistEntry("[::1]:8080", "[::1]") === true, "portless IPv6 matches any port");
+
+    suite("isHostAllowlisted CIDR matching (issue #64)");
+    assert(isHostAllowlisted("192.168.1.50:8006", ["192.168.1.0/24"]) === true, "Proxmox-like origin in /24");
+    assert(isHostAllowlisted("192.168.2.50:8006", ["192.168.1.0/24"]) === false, "outside /24");
+    assert(isHostAllowlisted("10.0.5.1", ["10.0.0.0/8"]) === true, "in /8");
+    assert(isHostAllowlisted("fe80::abcd:1", ["fe80::/10"]) === true, "IPv6 in CIDR");
+
+    suite("requestMatchesAllowlist origin vs destination");
+    assert(
+        requestMatchesAllowlist("evil.example", "127.0.0.1:80", ["127.0.0.1"]) === true,
+        "IP entry matches destination from untrusted origin"
+    );
+    assert(
+        requestMatchesAllowlist("evil.example", "10.0.0.1:80", ["127.0.0.1"]) === false,
+        "IP entry does not match other destination"
+    );
+    assert(
+        requestMatchesAllowlist("evil.example", "127.0.0.1:80", ["discord.com"]) === false,
+        "domain entry does not match destinations"
+    );
+    assert(
+        requestMatchesAllowlist("discord.com", "127.0.0.1:80", ["discord.com"]) === true,
+        "domain entry matches origin"
+    );
+    assert(
+        requestMatchesAllowlist("", "127.0.0.1:80", ["127.0.0.1"]) === true,
+        "file:// empty origin still matches IP destination"
+    );
+    assert(
+        requestMatchesAllowlist("evil.example", "192.168.1.50:8008", ["192.168.1.0/24"]) === true,
+        "CIDR entry matches destination"
+    );
+    assert(
+        requestMatchesAllowlist("192.168.1.50:8006", "192.168.1.50:8008", ["192.168.1.0/24"]) === true,
+        "CIDR matches Proxmox origin"
+    );
 }

--- a/tests/manifest.test.js
+++ b/tests/manifest.test.js
@@ -61,7 +61,7 @@ export async function run() {
     assert(requestFilter.includes("lexisnexisrisk.com"), "lists lexisnexisrisk.com");
     assert(requestFilter.includes("lnrsoftware.com"), "lists lnrsoftware.com");
     assert(requestFilter.includes('from "./allowlist.js"'), "uses shared allowlist helper");
-    assert(requestFilter.includes("isHostAllowlisted"), "delegates allowlist checks");
+    assert(requestFilter.includes("requestMatchesAllowlist"), "delegates allowlist checks");
     assert(requestFilter.includes('from "./privateAddress.js"'), "imports privateAddress helpers");
 
     suite("privateAddress.js owns hostname normalization");
@@ -71,7 +71,7 @@ export async function run() {
     suite("settings.js uses shared allowlist helper");
     const settings = readText("settings/settings.js");
     assert(settings.includes('from "../global/allowlist.js"'), "imports allowlist module");
-    assert(settings.includes("extractURLHost"), "uses extractURLHost");
+    assert(settings.includes("normalizeAllowlistEntry"), "uses normalizeAllowlistEntry");
 
     suite("core modules exist");
     for (const path of [

--- a/tests/privateAddress.test.js
+++ b/tests/privateAddress.test.js
@@ -11,6 +11,7 @@ import {
     hostnameSuggestsIpRebinding,
     isUnspecifiedAddress,
     normalizeHostname,
+    unwrapIpv4MappedAddress,
 } from "../global/privateAddress.js";
 import { suite, assert, assertEqual } from "./harness.js";
 
@@ -187,6 +188,17 @@ export async function run() {
     assert(isUnspecifiedAddress("127.0.0.1") === false, "loopback is not unspecified");
     assert(isUnspecifiedAddress("8.8.8.8") === false, "public is not unspecified");
     assert(isUnspecifiedAddress("::1") === false, "loopback v6 is not unspecified");
+
+    suite("unwrapIpv4MappedAddress");
+    assertEqual(unwrapIpv4MappedAddress("::ffff:127.0.0.1"), "127.0.0.1", "dotted mapped loopback");
+    assertEqual(unwrapIpv4MappedAddress("::ffff:7f00:1"), "127.0.0.1", "hex mapped loopback");
+    assertEqual(unwrapIpv4MappedAddress("[::ffff:192.168.1.50]"), "192.168.1.50", "bracketed mapped LAN");
+    assertEqual(unwrapIpv4MappedAddress("::192.168.0.1"), "192.168.0.1", "IPv4-compatible unwrap");
+    assertEqual(unwrapIpv4MappedAddress("::c0a8:1"), "192.168.0.1", "IPv4-compatible hex unwrap");
+    assertEqual(unwrapIpv4MappedAddress("127.0.0.1"), "127.0.0.1", "plain IPv4 unchanged");
+    assertEqual(unwrapIpv4MappedAddress("::1"), "::1", "native IPv6 loopback unchanged");
+    assertEqual(unwrapIpv4MappedAddress("::"), "::", "unspecified IPv6 unchanged");
+    assertEqual(unwrapIpv4MappedAddress("example.com"), "example.com", "domain unchanged");
 
     suite("normalizeHostname");
     assertEqual(normalizeHostname("Example.COM."), "example.com", "strips trailing dots + lowercases");

--- a/tests/requestFilter.test.js
+++ b/tests/requestFilter.test.js
@@ -89,6 +89,51 @@ export async function run() {
         );
         assertEqual(result.cancel, false, "allowlist matches host:port exactly");
     }
+    {
+        // Issue #66: portless IP allowlist matches origin on any port
+        const result = await evaluateRequest(
+            req({ originUrl: "http://127.0.0.1:3000/" }),
+            deps({ getAllowedDomains: async () => ["127.0.0.1"] })
+        );
+        assertEqual(result.cancel, false, "portless IP allowlist matches origin:port");
+        assertEqual(result.reason, "allowlisted", "allowlisted via IP");
+    }
+    {
+        // Issue #64: CIDR allowlist matches Proxmox-like LAN origins
+        const result = await evaluateRequest(
+            req({
+                originUrl: "https://192.168.1.50:8006/",
+                url: "https://192.168.1.50:8008/",
+            }),
+            deps({ getAllowedDomains: async () => ["192.168.1.0/24"] })
+        );
+        assertEqual(result.cancel, false, "CIDR allowlist matches LAN origin");
+        assertEqual(result.reason, "allowlisted", "allowlisted via CIDR");
+    }
+    {
+        // IP allowlist also matches scan destinations (e.g. TestPortScans from file://)
+        const result = await evaluateRequest(
+            req({
+                originUrl: "file:///tmp/TestPortScans.html",
+                url: "http://127.0.0.1:80/",
+            }),
+            deps({ getAllowedDomains: async () => ["127.0.0.1"] })
+        );
+        assertEqual(result.cancel, false, "IP allowlist matches destination from file://");
+        assertEqual(result.reason, "allowlisted", "allowlisted via destination IP");
+    }
+    {
+        // Domain allowlist must NOT open all destinations
+        const result = await evaluateRequest(
+            req({
+                originUrl: "https://evil.example/",
+                url: "http://127.0.0.1:80/",
+            }),
+            deps({ getAllowedDomains: async () => ["discord.com"] })
+        );
+        assertEqual(result.cancel, true, "domain allowlist does not match destinations");
+        assertEqual(result.reason, "portscan", "still blocked as portscan");
+    }
 
     suite("malformed URLs fail open");
     {

--- a/tests/requestFilter.test.js
+++ b/tests/requestFilter.test.js
@@ -135,6 +135,77 @@ export async function run() {
         assertEqual(result.reason, "portscan", "still blocked as portscan");
     }
 
+    suite("allowlist review-fix regressions (end-to-end)");
+    {
+        // Portless IPv6 must wildcard ports (URL.port-based, not host===hostname)
+        const result = await evaluateRequest(
+            req({
+                originUrl: "http://[::1]:3000/",
+                url: "http://[::1]:80/",
+            }),
+            deps({ getAllowedDomains: async () => ["[::1]"] })
+        );
+        assertEqual(result.cancel, false, "portless IPv6 allowlist matches origin:port");
+        assertEqual(result.reason, "allowlisted", "allowlisted via IPv6");
+    }
+    {
+        const result = await evaluateRequest(
+            req({
+                originUrl: "file:///tmp/TestPortScans.html",
+                url: "http://[::1]:80/",
+            }),
+            deps({ getAllowedDomains: async () => ["[::1]"] })
+        );
+        assertEqual(result.cancel, false, "portless IPv6 allowlist matches file:// destination");
+        assertEqual(result.reason, "allowlisted", "allowlisted via IPv6 destination");
+    }
+    {
+        // IPv4-mapped loopback must match a 127.0.0.1 allowlist entry
+        const result = await evaluateRequest(
+            req({
+                originUrl: "https://evil.example/",
+                url: "http://[::ffff:127.0.0.1]:80/",
+            }),
+            deps({ getAllowedDomains: async () => ["127.0.0.1"] })
+        );
+        assertEqual(result.cancel, false, "IPv4-mapped loopback destination matches 127.0.0.1");
+        assertEqual(result.reason, "allowlisted", "allowlisted via mapped unwrap");
+    }
+    {
+        const result = await evaluateRequest(
+            req({
+                originUrl: "http://[::ffff:192.168.1.50]:8006/",
+                url: "http://[::ffff:192.168.1.50]:8008/",
+            }),
+            deps({ getAllowedDomains: async () => ["192.168.1.0/24"] })
+        );
+        assertEqual(result.cancel, false, "IPv4-mapped LAN origin matches IPv4 CIDR");
+        assertEqual(result.reason, "allowlisted", "allowlisted via mapped CIDR");
+    }
+    {
+        // Without allowlist, mapped loopback is still a port scan
+        const result = await evaluateRequest(
+            req({
+                originUrl: "https://evil.example/",
+                url: "http://[::ffff:127.0.0.1]:80/",
+            }),
+            deps()
+        );
+        assertEqual(result.cancel, true, "mapped loopback still blocked without allowlist");
+        assertEqual(result.reason, "portscan", "portscan for mapped loopback");
+    }
+    {
+        const result = await evaluateRequest(
+            req({
+                originUrl: "https://10.0.0.1/",
+                url: "http://10.0.0.1:80/",
+            }),
+            deps({ getAllowedDomains: async () => ["192.168.1.0/24"] })
+        );
+        assertEqual(result.cancel, true, "origin outside CIDR still blocked");
+        assertEqual(result.reason, "portscan", "portscan outside CIDR");
+    }
+
     suite("malformed URLs fail open");
     {
         const result = await evaluateRequest(req({ originUrl: "not a url" }), deps());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #66 and #64 by making IP address and CIDR allowlist entries actually take effect.

## Problem

- **#66**: IP allowlist entries could be added but were ignored because origin hosts include ports (e.g. `127.0.0.1:8080`) while entries were stored without them.
- **#64**: Homelab users (e.g. Proxmox) need CIDR support for private subnets so shell/console connections are not blocked.

## Solution

- Portless IP entries match the same address on any port
- CIDR ranges match IPv4 and IPv6 origins/destinations
- `localhost` is treated as equivalent to `127.0.0.1` when matching against IP entries
- **Domain entries** still only match the page origin (e.g. `discord.com`)
- **IP and CIDR entries** match both the page origin and request destinations (so allowlisting `127.0.0.1` works from `file://` test pages too)

Matching lives in `global/allowlist.js` and reuses IP helpers from `global/privateAddress.js`. The preferences UI documents the new entry types.

## Example

| Page origin | Request target | Allowlist | Result |
|---|---|---|---|
| `127.0.0.1:3000` | `127.0.0.1:80` | `127.0.0.1` | Allowed |
| `192.168.1.50:8006` | `192.168.1.50:8008` | `192.168.1.0/24` | Allowed |
| `file://` (empty host) | `127.0.0.1:80` | `127.0.0.1` | Allowed |
| `evil.com` | `127.0.0.1:80` | `discord.com` | Blocked |
| `discord.com` | `127.0.0.1:80` | `discord.com` | Allowed |

## Test plan

- [x] Unit tests for IP/CIDR normalization, matching, and request-filter allowlist paths (`npm test` — 525 passed)
- [ ] Add `127.0.0.1` to allowlist, open `TestPortScans.html`, confirm loopback scans are not blocked
- [ ] Add LAN CIDR (e.g. `192.168.1.0/24`) and confirm Proxmox shell/console connections work
- [ ] Confirm `discord.com` allowlist still only applies to pages on discord.com

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46eb5638-738e-4e67-8e3b-21a12c602f4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46eb5638-738e-4e67-8e3b-21a12c602f4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

